### PR TITLE
Moved eco-counter url settings to env.

### DIFF
--- a/eco_counter/management/commands/import_eco_counter.py
+++ b/eco_counter/management/commands/import_eco_counter.py
@@ -68,10 +68,10 @@ from eco_counter.models import (
     ImportState
     )
 
-STATIONS_URL = "https://dev.turku.fi/datasets/ecocounter/liikennelaskimet.geojson"
-OBSERVATIONS_URL = "https://data.turku.fi/cjtv3brqr7gectdv7rfttc/counters-15min.csv"
-logger = logging.getLogger("eco_counter")
 
+logger = logging.getLogger("eco_counter")
+assert settings.ECO_COUNTER_STATIONS_URL, "Missing ECO_COUNTER_STATIONS_URL in env."
+assert settings.ECO_COUNTER_OBSERVATIONS_URL, "Missing ECO_COUNTER_OBSERVATIONS_URL in env."
 
 class Command(BaseCommand):
     help = "Imports Turku Traffic Volumes"
@@ -94,9 +94,9 @@ class Command(BaseCommand):
         ImportState.objects.all().delete()
 
     def get_dataframe(self):
-        response = requests.get(OBSERVATIONS_URL) 
+        response = requests.get(settings.ECO_COUNTER_OBSERVATIONS_URL) 
         assert response.status_code == 200, "Fetching observations csv {} status code: {}".\
-            format(OBSERVATIONS_URL, response.status_code)
+            format(settings.ECO_COUNTER_OBSERVATIONS_URL, response.status_code)
         string_data = response.content
         csv_data = pd.read_csv(io.StringIO(string_data.decode('utf-8')))
         return csv_data
@@ -190,9 +190,9 @@ class Command(BaseCommand):
             hour_data.save()       
 
     def save_stations(self):
-        response = requests.get(STATIONS_URL)
+        response = requests.get(settings.ECO_COUNTER_STATIONS_URL)
         assert response.status_code == 200, "Fetching stations from {} , status code {}"\
-            .format(STATIONS_URL, response.status_code)
+            .format(settings.ECO_COUNTER_STATIONS_URL, response.status_code)
         response_json = response.json()
         features = response_json["features"]
         saved = 0

--- a/smbackend/settings.py
+++ b/smbackend/settings.py
@@ -37,8 +37,9 @@ env = environ.Env(
     ACCESSIBILITY_SYSTEM_ID=(str, None),
     ADDITIONAL_INSTALLED_APPS=(list, None),
     ADDITIONAL_MIDDLEWARE=(list, None),
+    ECO_COUNTER_STATIONS_URL=(str, None),
+    ECO_COUNTER_OBSERVATIONS_URL=(str, None)
 )
-
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = root()
@@ -105,8 +106,17 @@ ROOT_URLCONF = "smbackend.urls"
 WSGI_APPLICATION = "smbackend.wsgi.application"
 
 # Database
-DATABASES = {"default": env.db()}
-
+#DATABASES = {"default": env.db()}
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'PORT': '5432',
+        'HOST': '127.0.0.1',
+        'NAME': 'servicemap',
+        'USER': 'servicemap',
+        'PASSWORD': 'servicemap',
+    }
+}
 # Keep the database connection open for 120s
 CONN_MAX_AGE = 120
 
@@ -365,3 +375,6 @@ if "SECRET_KEY" not in locals():
                 "Please create a %s file with random characters to generate your secret key!"
                 % secret_file
             )
+
+ECO_COUNTER_OBSERVATIONS_URL=env("ECO_COUNTER_OBSERVATIONS_URL")
+ECO_COUNTER_STATIONS_URL=env("ECO_COUNTER_STATIONS_URL")


### PR DESCRIPTION
## Moved urls that the eco-counter importer uses to env.

### Breakdown:

1. eco_counter/management/commands/import_eco_counter.py
   * Now reads the urls from settings.

2. smbackend/settings.py
   * Read the url used by the eco counter importer from the environment.