### PR TITLE
Rewrote the ID assignemnts to gas and charging station importers. Add…

### DIFF
--- a/smbackend/settings.py
+++ b/smbackend/settings.py
@@ -38,7 +38,9 @@ env = environ.Env(
     ADDITIONAL_INSTALLED_APPS=(list, None),
     ADDITIONAL_MIDDLEWARE=(list, None),
     ECO_COUNTER_STATIONS_URL=(str, None),
-    ECO_COUNTER_OBSERVATIONS_URL=(str, None), 
+    ECO_COUNTER_OBSERVATIONS_URL=(str, None),
+    GAS_FILLING_STATIONS_IDS=(dict, {}),
+    CHARGING_STATIONS_IDS=(dict, {}), 
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -380,3 +382,7 @@ if "SECRET_KEY" not in locals():
 
 ECO_COUNTER_OBSERVATIONS_URL=env("ECO_COUNTER_OBSERVATIONS_URL")
 ECO_COUNTER_STATIONS_URL=env("ECO_COUNTER_STATIONS_URL")
+
+# Typecast the dicts values to int with comporehension.
+GAS_FILLING_STATIONS_IDS={k: int(v) for k, v in env("GAS_FILLING_STATIONS_IDS").items()}
+CHARGING_STATIONS_IDS={k: int(v) for k, v in env("CHARGING_STATIONS_IDS").items()}

--- a/smbackend_turku/README.md
+++ b/smbackend_turku/README.md
@@ -22,13 +22,34 @@ ACCESSIBILITY_SYSTEM_ID=secret
 ## Importing external data sources
 
 Importing from external data sources should always be done after importing the services and units.
+To delete all data imported from external sources:
+```
+manage.py turku_services_import services units --delete-external-sources
+```
+
+When importing services and units the ids are received from the source. Therefore the ids for the external sources must be manually set to avoid
+id collisions. 
+The ids are set in a dict in the .env file with following keys:
+* service_node is the id of the service_node, recommended value < 3000000
+* service is the id of the service, recommended value > 1000
+* units_offset is the offset that will be given to the imported units ids, recommended value > 10000. 
+Example:
+GAS_FILLING_STATIONS_IDS=service_node=20000,service=20000,units_offset=20000
 
 ### Gas filling stations
+Add following line to the .env file:
+GAS_FILLING_STATIONS_IDS=service_node=20000,service=20000,units_offset=20000
+
+To import type:
 ```
 ./manage.py turku_services_import gas_filling_stations
 ```
 
 ### Charging stations
+Add following line to the .env file:
+CHARGING_STATIONS_IDS=service_node=30000,service=30000,units_offset=30000
+
+To import type:
 ```
 ./manage.py turku_services_import charging_stations
 ```

--- a/smbackend_turku/importers/units.py
+++ b/smbackend_turku/importers/units.py
@@ -113,18 +113,19 @@ def get_municipality(name):
 class UnitImporter:
     unitsyncher = ModelSyncher(Unit.objects.all(), lambda obj: obj.id)
 
-    def __init__(self, logger=None, importer=None):
+    def __init__(self, logger=None, importer=None, delete_external_sources=False):
         self.logger = logger
         self.importer = importer
+        self.delete_external_source = delete_external_sources
 
     def import_units(self):
         units = get_turku_resource("palvelupisteet")
 
         for unit in units:
             self._handle_unit(unit)
-
-        self._handle_external_units(GasFillingStationImporter)
-        self._handle_external_units(ChargingStationImporter)
+        if not self.delete_external_source:
+            self._handle_external_units(GasFillingStationImporter)
+            self._handle_external_units(ChargingStationImporter)
         self.unitsyncher.finish()
 
         update_service_node_counts()

--- a/smbackend_turku/management/commands/turku_services_import.py
+++ b/smbackend_turku/management/commands/turku_services_import.py
@@ -56,10 +56,21 @@ class Command(BaseCommand):
             default=False,
             help="import only single entity",
         )
+        parser.add_argument(
+            "--delete-external-sources",
+            action="store_true",
+            default=False,
+            help="If parameter is set when importing, deletes the external \
+                 sources imported with the importer."
+        )
 
     @db.transaction.atomic
     def import_services(self):
-        return import_services(logger=self.logger, importer=self)
+        return import_services(
+            logger=self.logger, 
+            importer=self,
+            delete_external_sources=self.delete_external_sources
+        )
 
     @db.transaction.atomic
     def import_accessibility(self):
@@ -67,7 +78,11 @@ class Command(BaseCommand):
 
     @db.transaction.atomic
     def import_units(self):
-        return import_units(logger=self.logger, importer=self)   
+        return import_units(
+            logger=self.logger, 
+            importer=self, 
+            delete_external_sources=self.delete_external_sources
+        )   
 
     @db.transaction.atomic
     def import_addresses(self):
@@ -94,8 +109,9 @@ class Command(BaseCommand):
         self.options = options
         self.verbosity = int(options.get("verbosity", 1))
         self.logger = logging.getLogger(__name__)
-
+        self.delete_external_sources = options.get("delete_external_sources", False)
         import_count = 0
+    
         for imp in self.importer_types:
             if imp not in self.options["import_types"]:
                 continue

--- a/smbackend_turku/tests/test_charging_stations.py
+++ b/smbackend_turku/tests/test_charging_stations.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from unittest.mock import patch
 import pytest
 import pytz
-from django.contrib.gis.geos import GEOSGeometry, Point, Polygon
+from django.conf import settings
 from services.models import Service, ServiceNode, Unit
 from smbackend_turku.tests.utils import (
     create_municipality,  
@@ -31,12 +31,17 @@ def test_charging_stations_import():
         root_service_node_name="TestRoot",
         test_data=get_test_resource(resource_name="charging_stations")
         )
-    assert Service.objects.get(name=Importer.SERVICE_NAME)
+    service = Service.objects.get(name=Importer.SERVICE_NAME)
+    assert service
+    assert service.id == settings.CHARGING_STATIONS_IDS["service"]
     service_node = ServiceNode.objects.get(name=Importer.SERVICE_NODE_NAME)
     assert service_node
+    assert service_node.id == settings.CHARGING_STATIONS_IDS["service_node"]
     assert service_node.parent.id == root_service_node.id
     
     assert Unit.objects.all().count() == 2
+    # second element thus descending order by id.
+    assert Unit.objects.all()[1].id == settings.CHARGING_STATIONS_IDS["units_offset"]
     assert Unit.objects.get(name="Hotel Kakola")
     unit = Unit.objects.get(name="AimoPark Stockmann Turku")
     assert unit  

--- a/smbackend_turku/tests/test_gas_filling_stations.py
+++ b/smbackend_turku/tests/test_gas_filling_stations.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from unittest.mock import patch
 import pytest
 import pytz
+from django.conf import settings
 from services.models import Service, ServiceNode, Unit
+from smbackend.settings import GAS_FILLING_STATIONS_IDS
 from smbackend_turku.tests.utils import (
     create_municipality,  
     get_test_resource,
@@ -30,12 +32,15 @@ def test_gas_filling_stations_import():
         root_service_node_name="TestRoot",
         test_data=get_test_resource(resource_name="gas_filling_stations")
         )
-    assert Service.objects.get(name=Importer.SERVICE_NAME)
+    service = Service.objects.get(name=Importer.SERVICE_NAME)
+    assert service
+    assert service.id == settings.GAS_FILLING_STATIONS_IDS["service"]
     service_node = ServiceNode.objects.get(name=Importer.SERVICE_NODE_NAME)
     assert service_node
-    assert service_node.parent.id == root_service_node.id
-  
+    assert service_node.id == settings.GAS_FILLING_STATIONS_IDS["service_node"]
+    assert service_node.parent.id == root_service_node.id  
     assert Unit.objects.all().count() == 2
+    assert Unit.objects.all()[1].id == settings.GAS_FILLING_STATIONS_IDS["units_offset"]
     assert Unit.objects.get(name="Raisio Kuninkoja")
     unit = Unit.objects.get(name="Turku Satama")
     assert unit  


### PR DESCRIPTION
# Fixed id collision bug by rewriting the id handling for external data sources. Now the ids are read from the .env file.

## Breakdown:

### General
1. smbackend/settings.py
    * Added GAS_FILLING_STATIONS_IDS and CHARGING_STATIONS_IDS env variables.
2. smbackend_turku/README.md
    * Added information about howto set the ids to env.
 
### Importers
1. smbackend_turku/importers/services.py
    * Added delete_external_sources parameter.
2.  smbackend_turku/importers/stations.py
     * Now assigns service and service_node ids that are set in the env also the offset for importer units ids are from the env. 
3.  smbackend_turku/importers/units.py
      * Added delete_external_sources parameter.
 4. smbackend_turku/management/commands/turku_services_import.py
     * Added delete_external_sources parameter.
### Tests
1. smbackend_turku/tests/test_charging_stations.py
    * Tests that the service, service_node and unit is assigned with correct ids.
2. smbackend_turku/tests/test_gas_filling_stations.py
    * Tests that the service, service_node and unit is assigned with correct ids.     