### PR TITLE
Now a charging station can have multiple chargers.

### DIFF
--- a/mobility_data/importers/charging_stations.py
+++ b/mobility_data/importers/charging_stations.py
@@ -15,7 +15,7 @@ from mobility_data.models import (
 logger = logging.getLogger("mobility_data")
 # The data comes from 2 different sources, the first contains basic info as position, address and type
 CHARGING_STATIONS_URL1 = "https://services1.arcgis.com/rhs5fjYxdOG1Et61/ArcGIS/rest/services/ChargingStations/FeatureServer/0/query?f=json&where=1=1&returnGeometry=true&spatialRel=esriSpatialRelIntersects&outFields=*"
-# The second contains additional info as count , operator and power.
+# The second contains info about the chargers as count , operator and power.
 CHARGING_STATIONS_URL2 = "https://services1.arcgis.com/rhs5fjYxdOG1Et61/ArcGIS/rest/services/ChargingStations/FeatureServer/1/query?f=json&where=1=1&returnGeometry=true&spatialRel=esriSpatialRelIntersects&outFields=*"
 
 
@@ -24,8 +24,9 @@ class ChargingStation:
     def __init__(self, elem, srid=settings.DEFAULT_SRID):
         self.is_active = True
         geometry = elem.get("geometry", None)
-        attributes = elem.get("attributes", None)   
-        self.object_id = attributes.get("OBJECTID", None)   
+        attributes = elem.get("attributes", None) 
+        # Location id is used as reference to chargers in second data source.  
+        self.location_id = attributes.get("LOCATION_ID", None)   
         x = geometry.get("x",0)
         y = geometry.get("y",0) 
         self.point = Point(x, y, srid=srid)
@@ -35,23 +36,22 @@ class ChargingStation:
         self.zip_code = temp_str.split(" ")[0]
         self.city = temp_str.split(" ")[1]
         self.url = attributes.get("URL", "")
-        self.charger_type = attributes.get("TYPE", "")        
-        self.url = attributes.get("URL", "")
         # address fields for service unit model
         self.street_address = self.address.split(",")[0]            
         self.address_postal_full = "{}{}".\
             format(self.address.split(",")[0], self.address.split(",")[1])
-        # Initialize additional fields
-        self.power = None
-        self.operator = None
-        self.count = None
+        # Initialize chargers as empty list
+        self.chargers = []      
 
-
-    def set_additional_fields(self, elem):      
-        self.power = elem.get("POWER", None)
-        self.count = elem.get("COUNT", None)
-        self.operator = elem.get("OPERATOR", None)
     
+    def add_charger(self, elem):
+        charger = {}
+        charger["type"] = elem.get("TYPE", None)
+        charger["power"] = elem.get("POWER", None)
+        charger["count"] = elem.get("COUNT", None)
+        charger["operator"] = elem.get("OPERATOR", None)
+        self.chargers.append(charger)
+        
 
 def get_filtered_charging_station_objects(json_data=None): 
     """
@@ -74,22 +74,20 @@ def get_filtered_charging_station_objects(json_data=None):
     
     # Fetch the second url with the additionl data.
     json_data = fetch_json(CHARGING_STATIONS_URL2)
-    # store all object_ids from filtered_object
-    object_ids = [o.object_id for o in filtered_objects]
- 
-    # Iterate through the json_data and if object id matches with filtered object add
-    #  additional fields  
+    # store all location_ids from filtered_object
+    location_ids = [o.location_id for o in filtered_objects]
+    # Iterate through the json_data and if location id matches with filtered object 
+    # add charger.
     for elem in json_data["features"]:
         attributes = elem.get("attributes", None)
-        object_id = attributes.get("OBJECTID")         
-        if object_id in object_ids:
-            # if object_id matches, set the additional fields. 
+        location_id = attributes.get("LOCATION_ID", 0)    
+        if location_id in location_ids:
+            # if location_id matches, add the charger 
             # i.e. the charging_station is in the filtered_objects     
             for object in filtered_objects:
-                if object.object_id == object_id:
-                    object.set_additional_fields(attributes)
-                    break          
-                   
+                if object.location_id == location_id:
+                    object.add_charger(attributes)
+                    #break             
     return filtered_objects
 
 
@@ -106,12 +104,9 @@ def save_to_database(objects, delete_tables=True):
         is_active = object.is_active 
         name = object.name
         address = object.address
-        extra = {}
-        extra["charger_type"] = object.charger_type
-        extra["power"] = object.power
-        extra["count"] = object.count 
-        extra["operator"] = object.operator
+        extra = {}       
         extra["url"] = object.url
+        extra["chargers"] = object.chargers
         extra["mobile_unit"] = MobileUnit.objects.create(
             is_active=is_active,
             name=name,

--- a/mobility_data/tests/test_import_charging_stations.py
+++ b/mobility_data/tests/test_import_charging_stations.py
@@ -29,4 +29,4 @@ def test_importer():
     # Transform to source data srid
     unit.geometry.transform(4326)
     assert pytest.approx(unit.geometry.x, 0.0001) == 22.247    
-    assert unit.extra["charger_type"] == "Type2"
+    assert unit.extra["url"] == "https://latauskartta.fi/latauspiste/2629/Hotel+Kakola/"

--- a/smbackend_turku/importers/stations.py
+++ b/smbackend_turku/importers/stations.py
@@ -225,16 +225,11 @@ class ChargingStationImporter():
             set_tku_translated_field(obj, "address_postal_full",\
                 create_language_dict(data_obj.address_postal_full))
             set_field(obj, "address_zip", data_obj.zip_code)
-            description = "Type: {} {}kW count:{} operator:{}".format(
-                data_obj.charger_type, data_obj.power, 
-                data_obj.count, data_obj.operator)  
+            description = "Charging station"  
             set_tku_translated_field(obj, "description",\
                 create_language_dict(description))
-            extra = {}
-            extra["charger_type"] = data_obj.charger_type
-            extra["power"] = data_obj.power
-            extra["count"] = data_obj.count 
-            extra["operator"] = data_obj.operator       
+            extra = {}          
+            extra["chargers"] = data_obj.chargers       
             set_field(obj, "extra", extra) 
             set_field(obj, "www", data_obj.url)
 

--- a/smbackend_turku/tests/test_charging_stations.py
+++ b/smbackend_turku/tests/test_charging_stations.py
@@ -49,7 +49,6 @@ def test_charging_stations_import():
     # Tranform to source data srid
     point.transform(4326)
     assert pytest.approx(unit.location.x, 0.0001) == 22.2632
-    assert unit.extra["charger_type"] == "Type2"
     assert unit.service_nodes.all().count() == 1
     assert unit.services.all().count() == 1
     assert unit.services.all()[0].name == Importer.SERVICE_NAME  


### PR DESCRIPTION
# Support for multiple chargers in one charger station

## Breakdown:
1. mobility_data/importers/charging_stations.py
    * Creates a list of chargers that is then set into the extra field.
2. mobility_data/tests/test_import_charging_stations.py
    * Replaced deprecated test.
3.  smbackend_turku/importers/stations.py
     * Sets the chargers into services_units extra field.
4.  smbackend_turku/tests/test_charging_stations.py
     * Removed deprecated test.