### PR TITLE
Search Units by their address

### DIFF
--- a/services/models/unit.py
+++ b/services/models/unit.py
@@ -271,11 +271,9 @@ class Unit(SoftDeleteModel):
             ("name_sv", "swedish", "A"),
             ("name_en", "english", "A"),
             ("extra", None, "B"),
-            # Commented out "temporarly" to reduce the amount
-            # of faulty search results.
-            # ("description_fi", "finnish", "D"),
-            # ("description_sv", "swedish", "D"),
-            # ("description_en", "english", "D"),
+            ("street_address_fi", "finnish", "D"),
+            ("street_address_sv", "swedish", "D"),
+            ("street_address_en", "english", "D"),     
         ]
 
     def soft_delete(self):

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -192,13 +192,13 @@ class SearchViewSet(GenericAPIView):
 
         if "order_units_by_num_services" in params:
             try:
-                order_units_by_num_serivces = strtobool(params["order_units_by_num_services"])
+                order_units_by_num_services = strtobool(params["order_units_by_num_services"])
             except ValueError:
                 raise ParseError("'order_units_by_num_services' needs to be a boolean")
         else:
-            order_units_by_num_serivces = True
+            order_units_by_num_services = True
 
-        if order_units_by_num_serivces:
+        if order_units_by_num_services:
             units_order_list.append("-num_services")
                        
         # Limit number of results in searchquery.

--- a/services/search/specification.swagger.yaml
+++ b/services/search/specification.swagger.yaml
@@ -36,6 +36,13 @@ components:
         type: string
       example: fi
       default: fi
+    order_units_by_num_services_param:
+      name: order_units_by_num_services
+      in: query
+      schema:
+        type: boolean
+        default: true
+      description: If set to false ordering by number of services is discarded in units results.   
     use_trigram_param:
       name: use_trigram
       in: query
@@ -150,6 +157,7 @@ paths:
         - $ref: "#/components/parameters/q_param"
         - $ref: "#/components/parameters/language_param"
         - $ref: "#/components/parameters/use_trigram_param"
+        - $ref: "#/components/parameters/order_units_by_num_services_param"
         - $ref: "#/components/parameters/sql_query_limit_param"
         - $ref: "#/components/parameters/unit_limit_param"
         - $ref: "#/components/parameters/service_limit_param"


### PR DESCRIPTION
# Search Unit by their address
## Street name is now included when generating the indexes to the search_column. Added param order_units_by_num_services which makes it possible to disable ordering the units by the number of services. 

### Breakdown:
1. services/models/unit.py
    * Added street_address field, settings and weights to the function that returns which columns shall be indexed to the search_column.
2. services/search/api.py
   * Added param order_units_by_num_services which makes it possible to disable ordering the units by the number of services. 
3. services/search/specification.swagger.yaml
    * Added the order_units_by_num_services param. 