### PR TITLE
Sql migration that creates GIN trigram indexes. Optimized get_trigram…

### DIFF
--- a/services/migrations/0090_trigram_index_service_and_unit_names.py
+++ b/services/migrations/0090_trigram_index_service_and_unit_names.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("services", "0089_create_service_names_fields"),
+    ]
+    operations = [
+        migrations.RunSQL(
+            sql="""
+            CREATE INDEX unit_name_fi_trgm_idx ON services_unit USING GIN (name_fi gin_trgm_ops);
+            CREATE INDEX unit_name_sv_trgm_idx ON services_unit USING GIN (name_sv gin_trgm_ops);
+            CREATE INDEX unit_name_en_trgm_idx ON services_unit USING GIN (name_en gin_trgm_ops);
+            CREATE INDEX service_name_fi_trgm_idx ON services_service USING GIN (name_fi gin_trgm_ops);
+            CREATE INDEX service_name_sv_trgm_idx ON services_service USING GIN (name_sv gin_trgm_ops);
+            CREATE INDEX service_name_en_trgm_idx ON services_service USING GIN (name_en gin_trgm_ops);
+            """,
+            reverse_sql="""
+            DROP INDEX unit_name_fi_trgm_idx;
+            DROP INDEX unit_name_sv_trgm_idx;
+            DROP INDEX unit_name_en_trgm_idx;
+            DROP INDEX service_name_fi_trgm_idx;
+            DROP INDEX service_name_sv_trgm_idx;
+            DROP INDEX service_name_en_trgm_idx;          
+            """,
+        ),
+    ]

--- a/services/search/specification.swagger.yaml
+++ b/services/search/specification.swagger.yaml
@@ -46,12 +46,15 @@ components:
     use_trigram_param:
       name: use_trigram
       in: query
-      description: Use trigram search to get search results by using trigram search, 
-      if no results are found for the model. Default is True. 
+      description: A comma-separeted list of resource types that will include
+      trigram results in search if no results are found. Possible values are
+       *service*, *unit*, *address* and *administrative_division*. 
+      If not present, defualts to unit and service. If list is empty trigram
+      will not be used.
       schema:
-        type: boolean
-        example: false
-        default: true
+        type: string
+        example: unit,address
+        default: unit,service
     sql_query_limit_param:
       name: sql_query_limit
       in: query
@@ -108,9 +111,9 @@ components:
     type_param:
       name: type
       in: query
-      description: A comma-separet list of resource types to be returned 
+      description: A comma-separeted list of resource types to be returned 
       in the results Possible values are *service*, *unit*, *address* and 
-      *administrative_division*. If not present, defualts to all types.
+      *administrativedivision*. If not present, defualts to all types.
       schema:
         type: string
     municipality_param:


### PR DESCRIPTION
# Trigram search optimization and changed the use_trigram param to take a comma separated list of resource that will use trigram.

### Breakdown 
1.  services/migrations/0090_trigram_index_service_and_unit_names.py
    * SQL migration that creates the trigram indexes. 
2. services/search/api.py
    * Optimized version of get_trigram_results. Resource specific checking of use_trigram param.
3. services/search/specification.swagger.yaml
    * Updated use_trigram param documentation.