### PR TITLE
Feature/import addresses from wfs

### DIFF
--- a/smbackend_turku/importers/addresses.py
+++ b/smbackend_turku/importers/addresses.py
@@ -1,21 +1,19 @@
-import csv
-import os
-
-from django.conf import settings
-from django.contrib.gis.geos import Point
-
-import logging
 import re
 from datetime import datetime
-from django.db.utils import IntegrityError
-from django.contrib.gis.gdal import DataSource
-from munigeo.models import Address, get_default_srid, Municipality, Street
 
-# As munigeos get_default_srid function returns wrong srid,
-#  use srid 3877 instead which is the correct srid.
+from django.conf import settings
+from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.geos import Point
+from django.db.utils import IntegrityError
+from munigeo.models import Address, Municipality, Street
+
 SOURCE_DATA_SRID = 3877
-URL="https://opaskartta.turku.fi/TeklaOGCWeb/WFS.ashx?service=WFS&request=GetFeature&typeName=GIS:Osoitteet&outputFormat=GML3&maxFeatures=80000"
-MUNICIPALITIES = {  
+SOURCE_DATA_URL = f"{settings.TURKU_WFS_URL}"\
+    "?service=WFS&request=GetFeature&typeName=GIS:Osoitteet&outputFormat=GML3&maxFeatures=80000"
+# NOTE "django.contrib.gis ERROR: GDAL_ERROR 1: b"Value 'UNKNOWN FIELD 'AddAddress.AddressNumberInt''
+# of field Osoitteet.Osoitenumero_luku parsed incompletely to integer 0." Is caused by faulty source data.
+
+MUNICIPALITIES = {
     # VARISNAIS-SUOMI
     19: ("Aura", "Aura"),
     202: ("Kaarina", "S:t Karins"),
@@ -38,7 +36,7 @@ MUNICIPALITIES = {
     636: ("Pöytyä", "Pöytis"),
     680: ("Raisio", "Reso"),
     704: ("Rusko", "Rusko"),
-    734: ("Salo", "Salo"), 
+    734: ("Salo", "Salo"),
     738: ("Sauvo", "Sagu"),
     761: ("Somero", "Somero"),
     833: ("Taivassalo", "Tövsala"),
@@ -49,28 +47,25 @@ MUNICIPALITIES = {
 
 
 class AddressImporter:
-    
-    def __init__(self, logger, layer=None):
-        self.logger = logging.getLogger("search")
-
+    def __init__(self, logger=None, layer=None):
+        self.logger = logger
         if not layer:
-            ds = DataSource(URL)
+            ds = DataSource(SOURCE_DATA_URL)
             self.layer = ds[0]
         else:
             self.layer = layer
-        #self.logger.setLevel(logging.INFO)
 
     def get_number_and_letter(self, number_letter):
         number = re.split(r"[a-zA-Z]+", number_letter)[0]
-        letter = re.split(r"[0-9]+", number_letter)[-1]                        
-        return number, letter       
-  
+        letter = re.split(r"[0-9]+", number_letter)[-1]
+        return number, letter
+
     def import_addresses(self):
         start_time = datetime.now()
-        self.logger.info("Importing addresses.")
+
         Street.objects.all().delete()
-        Address.objects.all().delete()      
-        
+        Address.objects.all().delete()
+
         num_incomplete = 0
         num_duplicates = 0
         entries_created = 0
@@ -81,48 +76,66 @@ class AddressImporter:
             # zip_code = feature["Postinumero"].as_string()
             if not name_sv:
                 name_sv = name_fi
-            municipality_num = feature["Kuntanumero"].as_int() 
+            municipality_num = feature["Kuntanumero"].as_int()
             geometry = feature.geom
             point = Point(geometry.x, geometry.y, srid=SOURCE_DATA_SRID)
             number_letter = feature["Osoitenumero"].as_string()
+            # The source data may contain empty entries and they are discarded.
             if not name_fi or not municipality_num or not geometry:
-                num_incomplete += 1                
+                num_incomplete += 1
                 continue
-           
+
             number = None
             number_end = None
             letter = None
             if number_letter:
+                # for number_letter of type "1-4" or "1-4b"
                 if re.search(r"-", number_letter):
                     tmp = number_letter.split("-")
                     number = tmp[0]
+                    # If number_end contains a letter. e.g. "1-4b"
                     if re.search(r"[a-zA-Z]+", tmp[1]):
-                        number_end, letter = self.get_number_and_letter(tmp[1])                 
+                        number_end, letter = self.get_number_and_letter(tmp[1])
                     else:
-                        number_end = tmp[1]                        
+                        number_end = tmp[1]
+                # number_letter of type "1b" or "123b"
                 elif re.search(r"[a-zA-Z]+", number_letter):
-                    number, letter = self.get_number_and_letter(number_letter)                 
+                    number, letter = self.get_number_and_letter(number_letter)
+                # Only a number e.g. "42"
                 else:
                     number = number_letter
-            municipality = Municipality.objects.get(id=MUNICIPALITIES[municipality_num][0].lower())
-            
+            try:
+                municipality = Municipality.objects.get(
+                    id=MUNICIPALITIES[municipality_num][0].lower()
+                )
+            except KeyError:
+                self.logger.warning(
+                    f"Municipality number {municipality_num} not found, discarding."
+                )
+                num_incomplete += 1
+                continue
+
             entry = {}
             entry["street"] = {}
-            entry["street"]["name_fi"]=name_fi
-            #entry["street"]["name_sv"]=name_sv
-            entry["street"]["municipality"]=municipality 
-            # TODO explain...why. unique constraint causes problem if wrong translation..           
-            if Street.objects.filter(**entry["street"]).exists():                
+            entry["street"]["name_fi"] = name_fi
+            entry["street"]["name_en"] = name_fi
+            entry["street"]["municipality"] = municipality
+
+            # The source data may have street names with wrong/conflicting swedish translations
+            # to avoid setting these to the db we must check the existens before getting and
+            # if not exists we set the swedish name to the entry before creating.
+            if Street.objects.filter(**entry["street"]).exists():
                 street = Street.objects.get(**entry["street"])
-                # There are cases where the name_sv is wrong in the input data.
                 if street.name_sv != name_sv:
-                    print("Street exists: ", entry["street"])
-                    print("different names")
+                    self.logger.warning(
+                        f"Found street name with wrong/conflicting swedish translation fi: {name_fi} sv: {name_sv}"
+                    )
+
             else:
-                entry["street"]["name_sv"]=name_sv
-                street = Street.objects.create(**entry["street"])          
-            
-            # Create full name that will be used when creating search_columns
+                entry["street"]["name_sv"] = name_sv
+                street = Street.objects.create(**entry["street"])
+
+            # Create full_name that will be used when populating search_column.
             full_name_fi = f"{name_fi} {number_letter}"
             full_name_sv = f"{name_sv} {number_letter}"
             entry["address"] = {}
@@ -131,128 +144,39 @@ class AddressImporter:
             entry["address"]["full_name_fi"] = full_name_fi
             entry["address"]["full_name_sv"] = full_name_sv
             entry["address"]["full_name_en"] = full_name_fi
+
             if number:
                 entry["address"]["number"] = number
             if number_end:
                 entry["address"]["number_end"] = number_end
             if letter:
                 entry["address"]["letter"] = letter
-           
+
             try:
                 Address.objects.get_or_create(**entry["address"])
-            except IntegrityError as e:
-                # Duplicate address causes Integrity error as the unique constraints fails
+            except IntegrityError:
+                # Duplicate address causes Integrity error as the unique constraints fails.
+                # and they are discarded thus they would confuse when e.g. searching for
+                # addresses.
                 num_duplicates += 1
-              
+
             entries_created += 1
             if entries_created % 1000 == 0:
-                self.logger.info("{}/{}".format(entries_created, len(self.layer)))
+                self.logger.info(
+                    "Imported: {}/{}".format(entries_created, len(self.layer))
+                )
 
         end_time = datetime.now()
         duration = end_time - start_time
-        self.logger.info("Imported {} streets and {} anddresses in {}".format(
-            Street.objects.all().count(), Address.objects.all().count(), duration
-        ))
+        self.logger.info(
+            "Imported {} streets and {} anddresses in {}".format(
+                Street.objects.all().count(), Address.objects.all().count(), duration
+            )
+        )
         self.logger.info("Discarded {} duplicates.".format(num_duplicates))
         self.logger.info("Discarded {} incomplete.".format(num_incomplete))
-
-        
-        
-
-class AddressImporterOLD:
-    def __init__(self, logger):
-        self.logger = logger
-
-        if hasattr(settings, "PROJECT_ROOT"):
-            root_dir = settings.PROJECT_ROOT
-        else:
-            root_dir = settings.BASE_DIR
-        self.data_path = os.path.join(root_dir, "data")
-
-        self.csv_field_names = ("municipality", "street", "street_number", "y", "x")
-        self.valid_municipalities = ["turku", "åbo"]
-
-    def _import_address(self, entry):
-        street, _ = Street.objects.get_or_create(**entry["street"])
-        location = Point(srid=SOURCE_DATA_SRID, **entry["point"])
-
-        Address.objects.get_or_create(
-            street=street, defaults={"location": location}, **entry["address"]
-        )
-
-    def _create_address_mapping(self, address_reader):
-        turku = Municipality.objects.get(id="turku")
-        multi_lingual_addresses = {}
-        for row in address_reader:
-            if row["municipality"].lower() not in self.valid_municipalities:
-                continue
-
-            coordinates = row["y"] + row["x"]
-            if coordinates not in multi_lingual_addresses:
-                # Create a point with a srid, so the coordinates are stored correctly.
-                point = Point(float(row["x"]), float(row["y"]), srid=SOURCE_DATA_SRID)
-                multi_lingual_addresses[coordinates] = {
-                    "street": {"municipality": turku},
-                    "point": {"x": point.x, "y": point.y},
-                    "address": {"number": row["street_number"]},
-                }
-            full_name = f"{row['street']} {row['street_number']}"
-            if row["municipality"].lower() == "turku":
-                multi_lingual_addresses[coordinates]["street"]["name_fi"] = row[
-                    "street"
-                ]
-                multi_lingual_addresses[coordinates]["address"][
-                    "full_name_fi"
-                ] = full_name
-
-            elif row["municipality"].lower() == "åbo":
-                # If we don't have a Finnish name for the street, use the Swedish name
-                # for the Finnish street name as well since that is most likely an
-                # expected value. If there is a Finnish name for the coordinates lower
-                # down in the coordinate list then the Finnish name will be overridden.
-                if "name_fi" not in multi_lingual_addresses[coordinates]["street"]:
-                    multi_lingual_addresses[coordinates]["street"]["name_fi"] = row[
-                        "street"
-                    ]
-                multi_lingual_addresses[coordinates]["street"]["name_sv"] = row[
-                    "street"
-                ]
-                multi_lingual_addresses[coordinates]["address"][
-                    "full_name_sv"
-                ] = full_name
-
-        return multi_lingual_addresses
-
-    def import_addresses(self):
-        file_path = os.path.join(self.data_path, "turku_addresses.csv")
-        print("file", file_path)
-        entries_created = 0
-
-        Street.objects.all().delete()
-        Address.objects.all().delete()
-
-        with open(file_path, encoding="latin-1") as csvfile:
-            address_reader = csv.DictReader(
-                csvfile, delimiter=";", fieldnames=self.csv_field_names
-            )
-            multi_lingual_addresses = self._create_address_mapping(address_reader)
-
-            for entry in multi_lingual_addresses.values():
-                self._import_address(entry)
-
-                entries_created += 1
-                if entries_created % 1000 == 0:
-                    self.logger.debug(
-                        "row {} / {}".format(
-                            entries_created, len(multi_lingual_addresses.values())
-                        )
-                    )
-
-        self.logger.debug("Added {} addresses".format(entries_created))
-
+        self.logger.info("Saving addresses and streets to database, this might take a while...")
 
 def import_addresses(**kwargs):
-   
     importer = AddressImporter(**kwargs)
-   
     return importer.import_addresses()

--- a/smbackend_turku/tests/data/turku_addresses.csv
+++ b/smbackend_turku/tests/data/turku_addresses.csv
@@ -1,2 +1,0 @@
-Turku;Kuuvuorenkatu;15;6705247;23461366
-Turku;Valtaojantie;26;6702623;23459033

--- a/smbackend_turku/tests/data/turku_addresses.gml
+++ b/smbackend_turku/tests/data/turku_addresses.gml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:GIS="http://www.tekla.com/schemas/GIS" xmlns="http://www.tekla.com/schemas/GIS" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.tekla.com/schemas/GIS https://opaskartta.turku.fi/TeklaOGCWeb/WFS.ashx?SERVICE=WFS&amp;REQUEST=DescribeFeatureType&amp;typeName=GIS:Osoitteet ">
+ <gml:boundedBy>
+  <gml:Box srsName="http://www.opengis.net/gml/srs/epsg.xml#3877">
+   <gml:coordinates>23458147.254,6697796.876 23467402.988,6721220.091</gml:coordinates>
+  </gml:Box>
+ </gml:boundedBy><gml:featureMember>
+  <GIS:Osoitteet>
+    <GIS:Osoite_suomeksi>Rauhalankalliontie</GIS:Osoite_suomeksi>
+    <GIS:Osoitenumero>3</GIS:Osoitenumero>
+    <GIS:Osoitenumero_luku>3</GIS:Osoitenumero_luku>
+    <GIS:Postinumero>21620</GIS:Postinumero>
+    <GIS:Kuntanumero>202</GIS:Kuntanumero>
+    <GIS:Tekstin_suunta_gon>51.0515</GIS:Tekstin_suunta_gon>
+    <GIS:Geometry>
+      <gml:Point srsName="http://www.opengis.net/gml/srs/epsg.xml#3877">
+        <gml:name>3</gml:name>
+        <gml:pos>23466798.343 6697796.876</gml:pos>
+      </gml:Point>
+    </GIS:Geometry>
+  </GIS:Osoitteet>
+</gml:featureMember><gml:featureMember>
+  <GIS:Osoitteet>
+    <GIS:Osoite_suomeksi>Unikkopolku</GIS:Osoite_suomeksi>
+    <GIS:Osoite_ruotsiksi>Vallmostigen</GIS:Osoite_ruotsiksi>
+    <GIS:Osoitenumero>1-4</GIS:Osoitenumero>
+    <GIS:Osoitenumero_luku>4</GIS:Osoitenumero_luku>
+    <GIS:Postinumero>20320</GIS:Postinumero>
+    <GIS:Kuntanumero>853</GIS:Kuntanumero>
+    <GIS:Tekstin_suunta_gon>378.7968</GIS:Tekstin_suunta_gon>
+    <GIS:Geometry>
+      <gml:Point srsName="http://www.opengis.net/gml/srs/epsg.xml#3877">
+        <gml:name>4</gml:name>
+        <gml:pos>23458147.254 6709005.733</gml:pos>
+      </gml:Point>
+    </GIS:Geometry>
+  </GIS:Osoitteet>
+</gml:featureMember><gml:featureMember>
+  <GIS:Osoitteet>
+    <GIS:Osoite_suomeksi>Koppelonkatu</GIS:Osoite_suomeksi>
+    <GIS:Osoite_ruotsiksi>Tjädergatan</GIS:Osoite_ruotsiksi>
+    <GIS:Osoitenumero>13b</GIS:Osoitenumero>
+    <GIS:Osoitenumero_luku>13</GIS:Osoitenumero_luku>
+    <GIS:Postinumero>20610</GIS:Postinumero>
+    <GIS:Kuntanumero>853</GIS:Kuntanumero>
+    <GIS:Tekstin_suunta_gon>306.7084</GIS:Tekstin_suunta_gon>
+    <GIS:Geometry>
+      <gml:Point srsName="http://www.opengis.net/gml/srs/epsg.xml#3877">
+        <gml:name>13</gml:name>
+        <gml:pos>23464210.875 6703317.030</gml:pos>
+      </gml:Point>
+    </GIS:Geometry>
+  </GIS:Osoitteet>
+</gml:featureMember></wfs:FeatureCollection>

--- a/smbackend_turku/tests/test_accessibility_import.py
+++ b/smbackend_turku/tests/test_accessibility_import.py
@@ -12,7 +12,7 @@ from services.models import (
     UnitIdentifier,
 )
 from smbackend_turku.tests.test_units_import import (
-    create_municipality,
+    create_municipalities,
     get_test_resource,
 )
 
@@ -48,7 +48,7 @@ def test_accessibility_variables_import(
     )
 
     # Create Municipality needed for Units creation
-    create_municipality()
+    create_municipalities()
 
     # Create Units needed for Accessibility Import
     create_units()

--- a/smbackend_turku/tests/test_addresses_import.py
+++ b/smbackend_turku/tests/test_addresses_import.py
@@ -1,37 +1,40 @@
 import logging
-import math
 
 import pytest
-from munigeo.models import Address, get_default_srid
+from munigeo.models import Address, Street
 
 from smbackend_turku.importers.addresses import AddressImporter, SOURCE_DATA_SRID
-from smbackend_turku.tests.utils import create_municipality, get_location
-
+from smbackend_turku.tests.utils import create_municipalities, get_location, get_test_addresses_layer
 
 @pytest.mark.django_db
 def test_address_import():
     logger = logging.getLogger(__name__)
 
-    # Create Turku municipality
-    create_municipality()
-
-    address_importer = AddressImporter(logger=logger)
-    address_importer.data_path = "smbackend_turku/tests/data"
+    # Create Turku, Kaarina municipalities
+    create_municipalities()
+    address_importer = AddressImporter(logger=logger, layer=get_test_addresses_layer())
     address_importer.import_addresses()
+    assert Address.objects.count() == 3
+    assert Street.objects.count() == 3
+    streets = Street.objects.all()
+    # Test street without swedish name, should get the finnis name
+    assert streets[0].name_fi == "Rauhalankalliontie"
+    assert streets[0].name_sv == "Rauhalankalliontie"
 
-    addresses = Address.objects.count()
-    address_1 = Address.objects.get(id=1)
-    address_2 = Address.objects.get(id=2)
-
-    address_1_location = get_location(23461366, 6705247, SOURCE_DATA_SRID)
-    address_2_location = get_location(23459033, 6702623, SOURCE_DATA_SRID)
-
-    assert addresses == 2
-    assert address_1.street.name == "Kuuvuorenkatu"
-    assert address_2.street.name == "Valtaojantie"
-    assert address_1.number == "15"
-    assert address_2.number == "26"
-    assert math.isclose(address_1.location.x, address_1_location.x, rel_tol=1e-6)
-    assert math.isclose(address_1.location.y, address_1_location.y, rel_tol=1e-6)
-    assert math.isclose(address_2.location.x, address_2_location.x, rel_tol=1e-6)
-    assert math.isclose(address_2.location.y, address_2_location.y, rel_tol=1e-6)
+    assert streets[1].name_fi == "Unikkopolku"
+    assert streets[1].name_sv == "Vallmostigen"
+    addresses = Address.objects.all()
+    addr_rauhalankalliontie = addresses[0]
+    assert addr_rauhalankalliontie.number == "3"
+    assert addr_rauhalankalliontie.number_end == ""
+    assert addr_rauhalankalliontie.letter == ""
+    # test 1-4 number
+    addr_unikkopolku = addresses[1]
+    assert addr_unikkopolku.number == "1"
+    assert addr_unikkopolku.number_end == "4"
+    # test letter after number
+    addr_koppelonkatu = addresses[2]
+    addr_koppelonkatu.number == "13"
+    addr_koppelonkatu.letter == "b"
+    location = get_location(23464210.875, 6703317.030, SOURCE_DATA_SRID)
+    assert addr_koppelonkatu.location == location

--- a/smbackend_turku/tests/test_addresses_import.py
+++ b/smbackend_turku/tests/test_addresses_import.py
@@ -4,7 +4,12 @@ import pytest
 from munigeo.models import Address, Street
 
 from smbackend_turku.importers.addresses import AddressImporter, SOURCE_DATA_SRID
-from smbackend_turku.tests.utils import create_municipalities, get_location, get_test_addresses_layer
+from smbackend_turku.tests.utils import (
+    create_municipalities,
+    get_location,
+    get_test_addresses_layer,
+)
+
 
 @pytest.mark.django_db
 def test_address_import():
@@ -17,7 +22,7 @@ def test_address_import():
     assert Address.objects.count() == 3
     assert Street.objects.count() == 3
     streets = Street.objects.all()
-    # Test street without swedish name, should get the finnis name
+    # Test street without swedish name, should get the finnish name
     assert streets[0].name_fi == "Rauhalankalliontie"
     assert streets[0].name_sv == "Rauhalankalliontie"
 

--- a/smbackend_turku/tests/test_charging_stations.py
+++ b/smbackend_turku/tests/test_charging_stations.py
@@ -6,7 +6,7 @@ import pytz
 from django.conf import settings
 from services.models import Service, ServiceNode, Unit
 from smbackend_turku.tests.utils import (
-    create_municipality,  
+    create_municipalities,  
     get_test_resource,
 )
 from smbackend_turku.importers.stations import import_charging_stations
@@ -24,7 +24,7 @@ def test_charging_stations_import():
         )
     # Municipality must be created in order to update_service_node_count() 
     # to execute without errors 
-    create_municipality()
+    create_municipalities()
     #Import using fixture data
     import_charging_stations(
         logger=logger, 

--- a/smbackend_turku/tests/test_gas_filling_stations.py
+++ b/smbackend_turku/tests/test_gas_filling_stations.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from services.models import Service, ServiceNode, Unit
 from smbackend.settings import GAS_FILLING_STATIONS_IDS
 from smbackend_turku.tests.utils import (
-    create_municipality,  
+    create_municipalities,  
     get_test_resource,
 )
 from smbackend_turku.importers.stations import import_gas_filling_stations
@@ -25,7 +25,7 @@ def test_gas_filling_stations_import():
         )
     # Municipality must be created in order to update_service_node_count() 
     # to execute without errors 
-    create_municipality()
+    create_municipalities()
     #Import using fixture data
     import_gas_filling_stations(
         logger=logger, 

--- a/smbackend_turku/tests/test_units_import.py
+++ b/smbackend_turku/tests/test_units_import.py
@@ -10,7 +10,7 @@ from services.management.commands.services_import.services import (
 )
 from services.models import Service, ServiceNode, Unit, UnitConnection
 from smbackend_turku.tests.utils import (
-    create_municipality,
+    create_municipalities,
     get_location,
     get_opening_hours,
     get_test_resource,
@@ -26,7 +26,7 @@ def test_unit_import(resource):
     unit_importer = UnitImporter(logger=logger)
 
     # Create Turku municipality
-    create_municipality()
+    create_municipalities()
 
     ServiceNode.objects.create(id=333, name="Tontit", last_modified_time=timezone.now())
     service = Service.objects.create(

--- a/smbackend_turku/tests/utils.py
+++ b/smbackend_turku/tests/utils.py
@@ -25,9 +25,14 @@ def create_municipalities():
         type=division_type, id=2, name_fi="Kaarina"
     )
     Municipality.objects.create(
-        id="kaarina", name="Kaarina", name_fi="Kaarina", name_sv="S:t Karins", division=division
+        id="kaarina",
+        name="Kaarina",
+        name_fi="Kaarina",
+        name_sv="S:t Karins",
+        division=division,
     )
-    
+
+
 def get_test_resource(resource_name):
     """
     Mock calling the API by fetching dummy data from files.
@@ -47,20 +52,22 @@ def get_test_resource(resource_name):
     elif resource_name == "gas_filling_stations":
         file = os.path.join(data_path, "gas_filling_stations.json")
     elif resource_name == "charging_stations":
-        file = os.path.join(data_path, "charging_stations.json")   
+        file = os.path.join(data_path, "charging_stations.json")
     else:
         file = os.path.join(data_path, "units.json")
- 
+
     with open(file) as f:
         data = json.load(f)
     return data
+
 
 def get_test_addresses_layer():
     data_path = os.path.join(os.path.dirname(__file__), "data")
     file = os.path.join(data_path, "turku_addresses.gml")
     ds = DataSource(file)
     layer = ds[0]
-    return layer 
+    return layer
+
 
 def format_time(time_str):
     if not time_str:

--- a/smbackend_turku/tests/utils.py
+++ b/smbackend_turku/tests/utils.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from django.conf import settings
+from django.contrib.gis.gdal import DataSource
 from django.contrib.gis.geos import Point
 from munigeo.models import (
     AdministrativeDivision,
@@ -12,7 +13,7 @@ from munigeo.models import (
 from smbackend_turku.importers.utils import get_weekday_str
 
 
-def create_municipality():
+def create_municipalities():
     division_type = AdministrativeDivisionType.objects.create(id=1, type="muni")
     division = AdministrativeDivision.objects.create(
         type=division_type, id=1, name_fi="Turku"
@@ -20,7 +21,13 @@ def create_municipality():
     Municipality.objects.create(
         id="turku", name="Turku", name_fi="Turku", name_sv="Åbo", division=division
     )
-
+    division = AdministrativeDivision.objects.create(
+        type=division_type, id=2, name_fi="Kaarina"
+    )
+    Municipality.objects.create(
+        id="kaarina", name="Kaarina", name_fi="Kaarina", name_sv="S:t Karins", division=division
+    )
+    
 def get_test_resource(resource_name):
     """
     Mock calling the API by fetching dummy data from files.
@@ -40,7 +47,7 @@ def get_test_resource(resource_name):
     elif resource_name == "gas_filling_stations":
         file = os.path.join(data_path, "gas_filling_stations.json")
     elif resource_name == "charging_stations":
-        file = os.path.join(data_path, "charging_stations.json")
+        file = os.path.join(data_path, "charging_stations.json")   
     else:
         file = os.path.join(data_path, "units.json")
  
@@ -48,6 +55,12 @@ def get_test_resource(resource_name):
         data = json.load(f)
     return data
 
+def get_test_addresses_layer():
+    data_path = os.path.join(os.path.dirname(__file__), "data")
+    file = os.path.join(data_path, "turku_addresses.gml")
+    ds = DataSource(file)
+    layer = ds[0]
+    return layer 
 
 def format_time(time_str):
     if not time_str:
@@ -69,4 +82,5 @@ def get_opening_hours(opening_time, closing_time, weekday):
 def get_location(latitude, longitude, srid):
     point = Point(x=float(latitude), y=float(longitude), srid=srid)
     point.transform(settings.DEFAULT_SRID)
+
     return point


### PR DESCRIPTION
# Address importer that imports from  WFS (Web Feature Service) server the addresses and streets to the munigeo tables. 

### Breakdown:

#### Importer
1. smbackend_turku/importers/addresses.py
    * Now uses the open WFS server provided by the city of Turku to import the streets and addresses of Turku and Kaarina.
 
#### Tests
1. smbackend_turku/tests/data/turku_addresses.csv
    * Deleted old mockup data.
2. smbackend_turku/tests/data/turku_addresses.gml
    * Mockup data of streets and addresses in GML. 
3. smbackend_turku/tests/test_addresses_import.py
    * Tests for the WFS address importer and removed the old tests. 
4. smbackend_turku/tests/test_accessibility_import.py
5. smbackend_turku/tests/test_charging_stations.py
6. smbackend_turku/tests/test_gas_filling_stations.py
7. smbackend_turku/tests/test_units_import.py
8. smbackend_turku/tests/test_accessibility_import.py 
   * Changed create_municipality to create_municipalities
9. smbackend_turku/tests/utils.py
   * Added method get_test_addresses_layer that returns the mockup data, changed create_municipality method to create_municipalities(now creates Turku and Kaarina).

