### PR TITLE
Bugfix/pagination may yield inconsistent results

### DIFF
--- a/iot/models.py
+++ b/iot/models.py
@@ -1,7 +1,8 @@
-import requests
 import json
-from django.db import models
+
+import requests
 from django.core.exceptions import ValidationError
+from django.db import models
 
 
 class IoTDataSource(models.Model):
@@ -33,3 +34,6 @@ class IoTData(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     data_source = models.ForeignKey(IoTDataSource, on_delete=models.CASCADE)
     data = models.JSONField(null=True)
+
+    class Meta:
+        ordering = ["-created"]

--- a/iot/tests/test_api.py
+++ b/iot/tests/test_api.py
@@ -1,7 +1,7 @@
 import pytest
-from rest_framework.reverse import reverse
 from django.conf import settings
 from django.test import override_settings
+from rest_framework.reverse import reverse
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
@@ -11,5 +11,5 @@ def test_api(api_client, iot_data, iot_data_source):
     response = api_client.get(url)
     assert response.status_code == 200
     results = response.json()["results"]
-    assert results[0]["data"] == {"test": 42}
-    assert results[1]["data"] == {"Even more test": "Data"}
+    assert results[0]["data"] == {"Even more test": "Data"}
+    assert results[1]["data"] == {"test": 42}


### PR DESCRIPTION
# Fix for pagination pagination may yield inconsistens results error.
## Fixed by adding ordering to the IoTData model.

Breakdown
1. iot/models.py
    * Orders now the rows descending by the created column.
2. iot/tests/test_api.py
    * Changed the order of asserts to reflect the new ordering. 