### PR TITLE
Bugfix/test bicycle stands importer fails

### DIFF
--- a/mobility_data/tests/conftest.py
+++ b/mobility_data/tests/conftest.py
@@ -1,67 +1,65 @@
 import pytest
-from rest_framework.test import APIClient
 from django.conf import settings
-from django.contrib.gis.geos import Point
+from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from munigeo.models import (
-    Municipality,
     Address,
-    Street,
     AdministrativeDivision,
+    AdministrativeDivisionGeometry,
     AdministrativeDivisionType,
+    Municipality,
+    Street,
 )
-from ..models import (
-    MobileUnitGroup,
-    MobileUnit,
-    ContentType,
-    GroupType,   
-)
+from rest_framework.test import APIClient
+
+from ..models import ContentType, GroupType, MobileUnit, MobileUnitGroup
 
 
 @pytest.fixture
 def api_client():
     return APIClient()
 
+
 @pytest.mark.django_db
 @pytest.fixture
 def content_type():
     content_type = ContentType.objects.create(
-        type_name="TTT",
-        name="test",
-        description="test content type"
+        type_name="TTT", name="test", description="test content type"
     )
     return content_type
+
 
 @pytest.mark.django_db
 @pytest.fixture
 def group_type():
     group_type = GroupType.objects.create(
-        type_name="TGT",
-        name="test group",
-        description="test group type"
+        type_name="TGT", name="test group", description="test group type"
     )
     return group_type
 
+
 @pytest.mark.django_db
 @pytest.fixture
-def mobile_unit(content_type):   
+def mobile_unit(content_type):
     mobile_unit = MobileUnit.objects.create(
         name="Test mobileunit",
         description="Test description",
         content_type=content_type,
         geometry=Point(42.42, 21.21, srid=settings.DEFAULT_SRID),
-        extra={"test":"4242"}
+        extra={"test": "4242"},
     )
     return mobile_unit
 
+
 @pytest.mark.django_db
 @pytest.fixture
-def mobile_unit_group(group_type):   
+def mobile_unit_group(group_type):
     mobile_unit_group = MobileUnitGroup.objects.create(
         name="Test mobileunitgroup",
         description="Test description",
-        group_type=group_type,      
+        group_type=group_type,
     )
     return mobile_unit_group
+
 
 @pytest.mark.django_db
 @pytest.fixture
@@ -69,76 +67,87 @@ def municipality():
     muni = Municipality.objects.create(id="turku", name="Turku")
     return muni
 
+
 @pytest.mark.django_db
 @pytest.fixture
 def administrative_division_type():
     adm_div_type = AdministrativeDivisionType.objects.create(
-        id=1,
-        type="muni", 
-        name="Municipality"
+        id=1, type="muni", name="Municipality"
     )
     return adm_div_type
+
 
 @pytest.mark.django_db
 @pytest.fixture
 def administrative_division(administrative_division_type):
     adm_div = AdministrativeDivision.objects.get_or_create(
-        name="Turku",    
-        origin_id=853, 
-        type_id=1
+        id=1, name="Turku", origin_id=853, type_id=1
     )
     return adm_div
-  
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def administrative_division_geometry(administrative_division):
+    poly = Polygon(
+        (
+            (1, 1),
+            (1, 7000000),
+            (7000000, 7000000),
+            (7100000, 7100000),
+            (7000000, 1),
+            (1, 1),
+        ),
+        srid=3067,
+    )
+    multi_poly = MultiPolygon(poly, srid=3067)
+    adm_div_geom = AdministrativeDivisionGeometry.objects.create(
+        id=1, division_id=1, boundary=multi_poly
+    )
+    return adm_div_geom
+
+
 @pytest.mark.django_db
 @pytest.fixture
 def streets():
     streets = []
-    street = Street.objects.create(        
+    street = Street.objects.create(
         name="Test Street",
         name_fi="Test Street",
         name_sv="Test StreetSV",
-        municipality_id="turku"
+        municipality_id="turku",
     )
-    streets.append(street)   
-    street = Street.objects.create(       
+    streets.append(street)
+    street = Street.objects.create(
         name="Linnanpuisto",
         name_fi="Linnanpuisto",
         name_sv="LinnanpuistoSV",
-        municipality_id="turku"
+        municipality_id="turku",
     )
-    streets.append(street) 
-    street = Street.objects.create(       
+    streets.append(street)
+    street = Street.objects.create(
         name="Kristiinankatu",
         name_fi="Kristiinankatu",
         name_sv="Kristinegatan",
-        municipality_id="turku"
+        municipality_id="turku",
     )
-    streets.append(street) 
+    streets.append(street)
     return streets
+
 
 @pytest.mark.django_db
 @pytest.fixture
 def address(streets):
     location = Point(22.244, 60.444, srid=3877)
     address = Address.objects.create(
-        id=100,
-        location=location, 
-        street=streets[0], 
-        number=42
-    ) 
+        id=100, location=location, street=streets[0], number=42
+    )
     location = Point(22.241, 60.333, srid=3877)
     address = Address.objects.create(
-        id=101,
-        location=location, 
-        street=streets[1], 
-        number=24
-    )  
+        id=101, location=location, street=streets[1], number=24
+    )
     location = Point(22.241, 60.333, srid=3877)
     address = Address.objects.create(
-        id=102,
-        location=location, 
-        street=streets[2], 
-        number=24
-    )  
+        id=102, location=location, street=streets[2], number=24
+    )
     return address
-

--- a/mobility_data/tests/test_import_bicycle_stands.py
+++ b/mobility_data/tests/test_import_bicycle_stands.py
@@ -1,6 +1,8 @@
 from io import StringIO
+
 import pytest
 from django.core.management import call_command
+
 from mobility_data.models import MobileUnit
 
 
@@ -21,6 +23,7 @@ def test_importer(
     municipality,
     administrative_division_type,
     administrative_division,
+    administrative_division_geometry,
     streets,
     address,
 ):
@@ -38,28 +41,28 @@ def test_importer(
     assert stand_normal.name_en == "Linnanpuisto"
     extra = stand_normal.extra
     assert extra["model"] == "Normaali"
-    assert extra["maintained_by_turku"] == True
-    assert extra["covered"] == False
-    assert extra["hull_lockable"] == False
+    assert extra["maintained_by_turku"] is True
+    assert extra["covered"] is False
+    assert extra["hull_lockable"] is False
     assert extra["number_of_places"] == 24
     assert extra["number_of_stands"] == 2
     assert extra["number_of_stands"] == 2
 
     assert stand_covered_hull_lockable.name == "Pitkäpellonkatu"
     extra = stand_covered_hull_lockable.extra
-    assert extra["maintained_by_turku"] == True
-    assert extra["covered"] == True
-    assert extra["hull_lockable"] == True
+    assert extra["maintained_by_turku"] is True
+    assert extra["covered"] is True
+    assert extra["hull_lockable"] is True
     assert extra["number_of_places"] == 18
     assert extra["number_of_stands"] == 1
     # external stand has no street name, so the closes street name
     # is "Test Street".
     assert stand_external.name == "Test Street"
     extra = stand_external.extra
-    assert extra["maintained_by_turku"] == False
+    assert extra["maintained_by_turku"] is False
     # As there are no info for stand that are not maintained by turku
     # field are set to None.
-    assert extra["covered"] == None
-    assert extra["hull_lockable"] == None
-    assert extra["number_of_places"] == None
-    assert extra["number_of_stands"] == None
+    assert extra["covered"] is None
+    assert extra["hull_lockable"] is None
+    assert extra["number_of_places"] is None
+    assert extra["number_of_stands"] is None


### PR DESCRIPTION
# Fixes failing test_import_bicycle_stands.
## Added AdministrativeDivisionGeometry to fixtures, the bicycle importer uses it to find the name of the municipality.

### Breakdown

1. mobility_data/tests/conftest.py
    * Added AdministrativeDivisionGeometry object to fixtures.
2. mobility_data/tests/test_import_bicycle_stands.py
    * Added the AdministrativeDivisionGeometry fixture to the test. 