### PR TITLE
Feature/search finetuning

### DIFF
--- a/services/models/unit.py
+++ b/services/models/unit.py
@@ -281,7 +281,6 @@ class Unit(SoftDeleteModel):
                 ("service_names_fi", "finnish", "B"),
                 ("extra", None, "C"),
                 ("address_zip", None, "D"),
-                ("street_address_fi", "finnish", "D"),
             ]
         elif lang == "sv":
             return [
@@ -289,7 +288,6 @@ class Unit(SoftDeleteModel):
                 ("service_names_sv", "swedish", "B"),
                 ("extra", None, "C"),
                 ("address_zip", None, "D"),
-                ("street_address_sv", "swedish", "D"),
             ]
         elif lang == "en":
             return [
@@ -297,7 +295,6 @@ class Unit(SoftDeleteModel):
                 ("service_names_en", "english", "B"),
                 ("extra", None, "C"),
                 ("address_zip", None, "D"),
-                ("street_address_en", "english", "D"),
             ]
         else:
             return []

--- a/services/search/specification.swagger.yaml
+++ b/services/search/specification.swagger.yaml
@@ -50,7 +50,7 @@ components:
         example: unit,address
         default: unit
     trigram_threshold_param:
-      name: trigram_treshold
+      name: trigram_threshold
       in: query
       desription: The threshold value, if trigram similarity is greater-than or equal to this value return the result.
       type: number 

--- a/services/search/specification.swagger.yaml
+++ b/services/search/specification.swagger.yaml
@@ -48,7 +48,13 @@ components:
       schema:
         type: string
         example: unit,address
-        default: unit,service
+        default: unit
+    trigram_threshold_param:
+      name: trigram_treshold
+      in: query
+      desription: The threshold value, if trigram similarity is greater-than or equal to this value return the result.
+      type: number 
+      default: 0.15
     sql_query_limit_param:
       name: sql_query_limit
       in: query
@@ -152,6 +158,7 @@ paths:
         - $ref: "#/components/parameters/q_param"
         - $ref: "#/components/parameters/language_param"
         - $ref: "#/components/parameters/use_trigram_param"
+        - $ref: "#/components/parameters/trigram_threshold_param"
         - $ref: "#/components/parameters/order_units_by_num_services_param"
         - $ref: "#/components/parameters/extended_serializer_param"
         - $ref: "#/components/parameters/sql_query_limit_param"


### PR DESCRIPTION
#Search Fine-Tuning 


### Breakdown
1. services/models/unit.py
    * Removed street names from search indexing, they can give results to the user that may confuse why they are there. 
2. services/search/api.py
    * Added trigram_thresold query param, changed the default to 0.15 and removed services from default trigram search.
    * The higher default value should return improved matches and remove distant matches.
3. services/search/specification.swagger.yaml
    * Updated to reflect changes in API. 


