### PR TITLE
Feature/servicenode ids as list municipality filter to addresses

### DIFF
--- a/services/migrations/0093_combine_servicenodes_with_same_name.py
+++ b/services/migrations/0093_combine_servicenodes_with_same_name.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("services", "0092_update_search_view"),
+    ]
+    operations = [
+        migrations.RunSQL(
+            sql="""
+            CREATE OR REPLACE VIEW search_view as
+            SELECT concat('unit_', services_unit.id) AS id, name_fi, name_sv, name_en, search_column_fi, search_column_sv, search_column_en, 'Unit' AS type_name from services_unit
+            UNION
+            SELECT concat('service_', id) AS id, name_fi, name_sv, name_en, search_column_fi, search_column_sv, search_column_en, 'Service' AS type_name from services_service
+            UNION        
+            SELECT concat('servicenode_', string_agg(id::text, '_')) AS ids, name_fi, name_sv, name_en, search_column_fi, search_column_sv, search_column_en, 'ServiceNode' AS type_name from services_servicenode group by 2,3,4,5,6,7,8 
+            UNION
+            SELECT concat('administrativedivision_', id) AS id,  name_fi, name_sv, name_en, search_column_fi, search_column_sv, search_column_en, 'AdministrativeDivision' AS type_name from munigeo_administrativedivision
+            UNION
+            SELECT concat('address_', id) AS id,  full_name_fi as name_fi, full_name_sv as name_sv, full_name_en as name_en, search_column_fi, search_column_sv, search_column_en, 'Address' AS type_name from munigeo_address;
+            """,
+            reverse_sql="""
+            DROP VIEW search_view;
+            """,
+        ),
+    ]

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -81,8 +81,10 @@ class SearchSerializer(serializers.Serializer):
             object_type = "administrativedivision"
         else:
             return representation
+        if object_type == "servicenode":
+            representation["ids"] = self.context["service_node_ids"][str(obj.id)]
         # Address IDs are not serialized thus they changes after every import.
-        if object_type != "address":
+        if object_type not in ["address", "servicenode"]:
             representation["id"] = getattr(obj, "id")
         representation["object_type"] = object_type
         names = {}
@@ -148,6 +150,20 @@ class SearchSerializer(serializers.Serializer):
                     )
 
         return representation
+
+
+def get_service_node_results(all_results):
+    """
+    Returns a dict with the aggregated ids. Key is the first id in the results.
+    This dict is also sent as context to the serializer to output the ids list.
+    """
+    ids = {}
+    for row in all_results:
+        if row[1] == "ServiceNode":
+            # Id is the first col and in format type_42_43_44.
+            tmp = row[0].split("_")[1:]
+            ids[tmp[0]] = tmp[0:]
+    return ids
 
 
 def get_ids_from_sql_results(all_results, type="Unit"):
@@ -329,7 +345,8 @@ class SearchViewSet(GenericAPIView):
         all_ids = get_all_ids_from_sql_results(all_results)
         unit_ids = all_ids["Unit"]
         service_ids = all_ids["Service"]
-        service_node_ids = all_ids["ServiceNode"]
+        service_node_ids = get_service_node_results(all_results)
+
         administrative_division_ids = all_ids["AdministrativeDivision"]
         address_ids = all_ids["Address"]
 
@@ -380,7 +397,7 @@ class SearchViewSet(GenericAPIView):
                 municipalities = (
                     self.request.query_params["municipality"].lower().strip().split(",")
                 )
-                if municipalities[0]:
+                if len(municipalities) > 0:
                     units_qs = units_qs.filter(municipality_id__in=municipalities)
             if "service" in self.request.query_params:
                 services = self.request.query_params["service"].strip().split(",")
@@ -414,7 +431,8 @@ class SearchViewSet(GenericAPIView):
         else:
             administrative_divisions_qs = AdministrativeDivision.objects.none()
         if "servicenode" in types:
-            service_nodes_qs = ServiceNode.objects.filter(id__in=service_node_ids)
+            query_ids = [id[0] for id in service_node_ids.values()]
+            service_nodes_qs = ServiceNode.objects.filter(id__in=query_ids)
             if not service_nodes_qs and "servicenode" in use_trigram:
                 service_nodes_qs = get_trigram_results(
                     ServiceNode,
@@ -437,6 +455,14 @@ class SearchViewSet(GenericAPIView):
                     q_val,
                     threshold=trigram_threshold,
                 )
+            if "municipality" in self.request.query_params:
+                municipalities = (
+                    self.request.query_params["municipality"].lower().strip().split(",")
+                )
+                if len(municipalities) > 0:
+                    addresses_qs = addresses_qs.filter(
+                        street__municipality_id__in=municipalities
+                    )
             addresses_qs = addresses_qs[: model_limits["address"]]
         else:
             addresses_qs = Address.objects.none()
@@ -460,6 +486,11 @@ class SearchViewSet(GenericAPIView):
         )
         page = self.paginate_queryset(queryset)
         serializer = SearchSerializer(
-            page, many=True, context={"extended_serializer": extended_serializer}
+            page,
+            many=True,
+            context={
+                "extended_serializer": extended_serializer,
+                "service_node_ids": service_node_ids,
+            },
         )
         return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
# ServiceNode serializing and municipality filtering to addresses

## Now all the servicenodes with same name are serialized as one and their ids are presented in a "ids" field. 


-----------------------------------------------------------------------------------------------
### Breakdown:

#### 
 1. services/migrations/0093_combine_servicenodes_with_same_name.py
     * Migration that aggregates the ids,
   
 2. services/search/api.py
     * Added function that returns a dict with ServiceNode ids, it contains a list servicenodes with the same name. Now serializes the servicenodes ids field using this dict. 
 