### PR TITLE
Feature/postalcodearea serializer and new munigeo version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ django-modeltranslation
 flake8
 requests
 requests_cache
-git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.67#egg=django-munigeo
+git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.69#egg=django-munigeo
 pytz
 django-cors-headers
 django-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ django-mptt==0.13.4
     # via
     #   -r requirements.in
     #   django-munigeo
-django-munigeo @ git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.67
+django-munigeo @ git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.69
     # via -r requirements.in
 django-polymorphic==3.1.0
     # via -r requirements.in

--- a/services/api.py
+++ b/services/api.py
@@ -18,11 +18,10 @@ from django_filters.rest_framework import DjangoFilterBackend
 from modeltranslation.translator import NotRegistered, translator
 from mptt.utils import drilldown_tree_for_node
 from munigeo import api as munigeo_api
-from munigeo.models import Address, AdministrativeDivision, Municipality
+from munigeo.models import AdministrativeDivision, Municipality
 from rest_framework import generics, renderers, serializers, viewsets
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
-from pprint import pprint as pp
 
 from observations.models import Observation
 from services.accessibility import RULES
@@ -704,7 +703,7 @@ class UnitSerializer(
         qparams = self.context["request"].query_params
         if qparams.get("geometry", "").lower() in ("true", "1"):
             geom = obj.geometry  # TODO: different geom types
-            if geom and obj.geometry != obj.location:              
+            if geom and obj.geometry != obj.location:
                 ret["geometry"] = munigeo_api.geom_to_json(geom, self.srs)
         elif "geometry" in ret:
             del ret["geometry"]
@@ -1175,6 +1174,13 @@ class AddressViewSet(munigeo_api.AddressViewSet):
 
 
 register_view(AddressViewSet, "address")
+
+
+class PostalCodeAreaViewSet(munigeo_api.PostalCodeAreaViewSet):
+    serializers_class = munigeo_api.PostalCodeSerializer
+
+
+register_view(PostalCodeAreaViewSet, "postalcodearea")
 
 
 class AnnouncementSerializer(TranslatedModelSerializer, JSONAPISerializer):


### PR DESCRIPTION
# PostalCodeArea view and fix for munigeo

-----------------------------------------------------------------------------------------------
### Breakdown:
 1. requirements.in
 2. requirements.txt
     * Changed munigeo version to 0.2.69
This version includes serializer for PostalCodeAreas and serializes
PostalCodAareas for addresses. Also fixes requests_cache raising
TypeError when importing.
3. services/api.py
    * Added PostalCodeAreaViewSet