### PR TITLE
Feature/reorganize import tasks

### DIFF
--- a/smbackend_turku/README.md
+++ b/smbackend_turku/README.md
@@ -13,7 +13,9 @@ ACCESSIBILITY_SYSTEM_ID=secret
 ```
 And the Mobile view specific settings, see: config_dev.env.example
 
-## Importing data
+## Manually Importing data
+Note, All imports can be run from the Admin using Celery Tasks.
+
 ```
 ./manage.py geo_import finland --municipalities
 ./manage.py turku_services_import services accessibility units addresses

--- a/smbackend_turku/tasks.py
+++ b/smbackend_turku/tasks.py
@@ -9,6 +9,12 @@ def import_mds_data(name="import_mds_data"):
     )
 
 @shared_task
+def geo_import_municipalities(name="geo_import_municipalities"):
+    management.call_command(
+        "geo_import", "finland", "--municipalities"
+    )
+
+@shared_task
 def index_search_columns(name="index_search_columns"):
     management.call_command("index_search_columns")
 

--- a/smbackend_turku/tasks.py
+++ b/smbackend_turku/tasks.py
@@ -5,26 +5,35 @@ from django.core import management
 @shared_task
 def import_mds_data(name="import_mds_data"):
     management.call_command(
-        "turku_services_import", "services", "accessibility", "units", "addresses"
+        "turku_services_import", "services", "accessibility", "units"
     )
+
+
+@shared_task
+def import_addresses(name="import_addresses"):
+    # Imports addresses for Turku and Karina from the WFS server hosted by Turku
+    management.call_command("turku_services_import", "addresses")
+
 
 @shared_task
 def geo_import_municipalities(name="geo_import_municipalities"):
-    management.call_command(
-        "geo_import", "finland", "--municipalities"
-    )
+    management.call_command("geo_import", "finland", "--municipalities")
+
 
 @shared_task
 def index_search_columns(name="index_search_columns"):
     management.call_command("index_search_columns")
 
+
 @shared_task
 def import_geo_search_addresses(name="import_geo_search_addresses"):
+    # Imports the addresses of Southwest Finland(not Turku and Kaarina) from geo-search(paikkatietohaku)
     management.call_command("turku_services_import", "geo_search_addresses")
 
 
 @shared_task
 def import_enriched_addresses(name="import_enriched_addresses"):
+    # Enriches addresses for Turku and Karina from geo-search(paikkatietohaku)
     management.call_command("turku_services_import", "enriched_addresses")
 
 

--- a/smbackend_turku/tasks.py
+++ b/smbackend_turku/tasks.py
@@ -9,7 +9,7 @@ def import_mds_data(name="import_mds_data"):
     )
 
 @shared_task
-def index_search_columns(name="ndex_search_columns"):
+def index_search_columns(name="index_search_columns"):
     management.call_command("index_search_columns")
 
 @shared_task

--- a/smbackend_turku/tasks.py
+++ b/smbackend_turku/tasks.py
@@ -3,6 +3,11 @@ from django.core import management
 
 
 @shared_task
+def turku_services_import(args, name="turku_services_import"):
+    management.call_command("turku_services_import", args)
+
+
+@shared_task
 def import_mds_data(name="import_mds_data"):
     management.call_command(
         "turku_services_import", "services", "accessibility", "units"


### PR DESCRIPTION
# Reorganize import tasks

-----------------------------------------------------------------------------------------------
### Breakdown:
 1. smbackend_turku/tasks.py
     * Added Task to import municipalities, added task that only import addresses for Turku and Karina from WFS server, removed addresses from import_mds_data task. Added turku_services_import task that takes the target as argument.
   
 2. smbackend_turku/README.md
     * Added note of using Celery