### PR TITLE
Feature/search serialize root service node

### DIFF
--- a/services/models/service_node.py
+++ b/services/models/service_node.py
@@ -61,6 +61,15 @@ class ServiceNode(MPTTModel):
         )
         return count
 
+    @classmethod
+    def get_root_service_node(cls, service_node):
+        if service_node.parent_id is None:
+            return service_node
+        else:
+            return cls.get_root_service_node(
+                ServiceNode.objects.get(id=service_node.parent_id)
+            )
+
     def period_enabled(self):
         """Iterates through related services to find out
         if the tree node has periods enabled via services"""

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -60,7 +60,7 @@ from .utils import (
 logger = logging.getLogger("search")
 
 
-class RootSerivceNodeSerializer(TranslatedModelSerializer, serializers.ModelSerializer):
+class RootServiceNodeSerializer(TranslatedModelSerializer, serializers.ModelSerializer):
     class Meta:
         model = ServiceNode
         fields = ["id", "name"]
@@ -94,7 +94,7 @@ class SearchSerializer(serializers.Serializer):
             representation["ids"] = ids
             set_service_node_unit_count(ids, representation)
             root_service_node = ServiceNode.get_root_service_node(obj)
-            representation["root_service_node"] = RootSerivceNodeSerializer(
+            representation["root_service_node"] = RootServiceNodeSerializer(
                 root_service_node
             ).data
 
@@ -142,7 +142,7 @@ class SearchSerializer(serializers.Serializer):
 
             if object_type == "service":
                 set_service_unit_count(obj, representation)
-                representation["root_service_node"] = RootSerivceNodeSerializer(
+                representation["root_service_node"] = RootServiceNodeSerializer(
                     obj.root_service_node
                 ).data
 

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -21,6 +21,7 @@ import logging
 import re
 from distutils.util import strtobool
 from itertools import chain
+
 from django.db import connection, reset_queries
 from django.db.models import Count
 from munigeo import api as munigeo_api
@@ -59,6 +60,12 @@ from .utils import (
 logger = logging.getLogger("search")
 
 
+class RootSerivceNodeSerializer(TranslatedModelSerializer, serializers.ModelSerializer):
+    class Meta:
+        model = ServiceNode
+        fields = ["id", "name"]
+
+
 class DepartmentSerializer(TranslatedModelSerializer, serializers.ModelSerializer):
     class Meta:
         model = Department
@@ -86,6 +93,10 @@ class SearchSerializer(serializers.Serializer):
             ids = self.context["service_node_ids"][str(obj.id)]
             representation["ids"] = ids
             set_service_node_unit_count(ids, representation)
+            root_service_node = ServiceNode.get_root_service_node(obj)
+            representation["root_service_node"] = RootSerivceNodeSerializer(
+                root_service_node
+            ).data
 
         # Address IDs are not serialized thus they changes after every import.
         if object_type not in ["address", "servicenode"]:
@@ -131,6 +142,9 @@ class SearchSerializer(serializers.Serializer):
 
             if object_type == "service":
                 set_service_unit_count(obj, representation)
+                representation["root_service_node"] = RootSerivceNodeSerializer(
+                    obj.root_service_node
+                ).data
 
             if object_type == "unit" or object_type == "address":
                 if obj.location:


### PR DESCRIPTION
# Serialize the ID and name of the root ServiceNode for Services and ServiceNodes

-----------------------------------------------------------------------------------------------
### Breakdown:

#### 
 1. services/models/service_node.py
     * Static method that returns the root ServiceNode for the ServiceNode given as argument.
 2. services/search/api.py
     * RootServiceNodeSerializer and serializes field "root_service_node" for Services and ServiceNodes.
    


