### PR TITLE
Fix faulty handling of units

### DIFF
--- a/services/search/utils.py
+++ b/services/search/utils.py
@@ -30,12 +30,13 @@ def set_service_node_unit_count(ids, representation):
                 unit_counts[division] = count
     else:
         # Handle grouped service_nodes
-        units = []
+        units_qs = Unit.objects.none()
         for id in ids:
             service_node = ServiceNode.objects.get(id=id)
-            units += service_node.get_units()
-        unit_qs = Unit.objects.filter(id__in=units).distinct()
-        for unit in unit_qs:
+            units_qs = units_qs | service_node.get_units_qs()
+        units_qs = units_qs.distinct()
+        
+        for unit in units_qs:
             division = unit.municipality_id
             if not division:
                 continue


### PR DESCRIPTION
# Hotfix for faulty code when handling grouped service nodes.

## Description
Probably caused by not merging develop to the branch(https://github.com/City-of-Turku/smbackend/tree/feature/search-serialize-root-service-node/services/search)  before merging it to develop

### Breakdown:

 1. services/search/utils.py
     * Now contains the optimized and correct version of the code that selects the units which are to be counted per municipality
   
