### PR TITLE
Feature/bicycle stands import only if in turku

### DIFF
--- a/mobility_data/importers/bicycle_stands.py
+++ b/mobility_data/importers/bicycle_stands.py
@@ -48,7 +48,8 @@ class BicyleStand:
     @classmethod
     def locates_in_turku(cls, feature):
         """
-        Returns True if geometry inside Turku boundarys.
+        Returns True if the geometry of the feature is inside the boundaries
+        of Turku.
         """
         point = Point(feature.geom.x, feature.geom.y, srid=SOURCE_DATA_SRID)
         point.transform(settings.DEFAULT_SRID)

--- a/smbackend_turku/management/commands/turku_services_import.py
+++ b/smbackend_turku/management/commands/turku_services_import.py
@@ -24,6 +24,13 @@ from smbackend_turku.importers.units import import_units
 
 class Command(BaseCommand):
     help = "Import services from City of Turku APIs and from external sources."
+    external_sources = [
+        "gas_filling_stations",
+        "charging_stations",
+        "bicycle_stands",
+        "mobility_data",
+    ]
+
     importer_types = [
         "services",
         "accessibility",
@@ -31,11 +38,7 @@ class Command(BaseCommand):
         "addresses",
         "geo_search_addresses",
         "enriched_addresses",
-        "gas_filling_stations",
-        "charging_stations",
-        "bicycle_stands",
-        "mobility_data",
-    ]
+    ] + external_sources
 
     supported_languages = [lang[0] for lang in settings.LANGUAGES]
 
@@ -136,7 +139,6 @@ class Command(BaseCommand):
         self.logger = logging.getLogger("turku_services_import")
         self.delete_external_sources = options.get("delete_external_sources", False)
         import_count = 0
-
         for imp in self.importer_types:
             if imp not in self.options["import_types"]:
                 continue


### PR DESCRIPTION
# Imports now only if the bicyclestand is inside the boundaries of Turku

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. mobility_data/importers/bicycle_stands.py
     * Now checks if the features geometry is inside the boundaries. If inside import, else skip.
   
 2. smbackend_turku/management/commands/turku_services_import.py
     * Spitted importer types, now also external_sources list. 
    
 
