### PR TITLE
Feature/mobility data import payment zones

### DIFF
--- a/mobility_data/README.md
+++ b/mobility_data/README.md
@@ -3,7 +3,7 @@
 Django app for importing and serving data from external sources.  
 Add the TURKU_WFS_URL for the WFS server to the env, e.g.
 ```
-TURKU_WFS_URL=http://tkuikp.adturku.fi/TeklaOGCWeb/WFS.ashx
+TURKU_WFS_URL=https://opaskartta.turku.fi/TeklaOGCWeb/WFS.ashx
 ```
 
 ## importers
@@ -36,4 +36,10 @@ Culture routes are not deleted before importing. To explicity delete Culture Rou
 To import data type:  
 ```
 ./manage.py import_bicycle_stands 
+```
+
+### Payment Zones
+To import data type:
+```
+./manage.py import_payment_zones
 ```

--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -1,5 +1,5 @@
 from django.contrib.gis.gdal.error import GDALException
-from django.contrib.gis.geos import GEOSGeometry, LineString, Point
+from django.contrib.gis.geos import GEOSGeometry, LineString, Point, Polygon
 from rest_framework import serializers
 
 from services.models import Unit
@@ -110,5 +110,19 @@ class MobileUnitSerializer(serializers.ModelSerializer):
                 return coords
             else:
                 return geometry.coords
+
+        elif isinstance(geometry, Polygon):
+            if self.context["latlon"] is True:
+                # Return Polygon coordinates in (lat,lon) format
+                coords = []
+                for coord in list(*geometry.coords):
+                    # swap lon,lat -> lat lon
+                    e = (coord[1], coord[0])
+                    coords.append(e)
+                return coords
+            else:
+
+                return geometry.coords
+
         else:
             return ""

--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -121,8 +121,6 @@ class MobileUnitSerializer(serializers.ModelSerializer):
                     coords.append(e)
                 return coords
             else:
-
                 return geometry.coords
-
         else:
             return ""

--- a/mobility_data/api/views.py
+++ b/mobility_data/api/views.py
@@ -1,20 +1,17 @@
 from distutils.util import strtobool
+
 from django.core.exceptions import ValidationError
 from rest_framework import status, viewsets
-from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
-from ..models import (
-    MobileUnitGroup,
-    MobileUnit,
-    ContentType,
-    GroupType,
-)
+from rest_framework.response import Response
+
+from ..models import ContentType, GroupType, MobileUnit, MobileUnitGroup
 from .serializers import (
+    ContentTypeSerializer,
+    GroupTypeSerializer,
     MobileUnitGroupSerializer,
     MobileUnitGroupUnitsSerializer,
     MobileUnitSerializer,
-    GroupTypeSerializer,
-    ContentTypeSerializer,
 )
 
 
@@ -32,7 +29,7 @@ def get_srid_and_latlon(filters):
 
     if "latlon" in filters:
         try:
-            latlon = strtobool(filters["latlon"])
+            latlon = bool(strtobool(filters["latlon"]))
         except ValueError:
             raise ParseError("'latlon' needs to be a boolean")
     return srid, latlon
@@ -74,7 +71,6 @@ class MobileUnitGroupViewSet(viewsets.ReadOnlyModelViewSet):
             serializer_class = MobileUnitGroupUnitsSerializer
         else:
             serializer_class = MobileUnitGroupSerializer
-
         serializer = serializer_class(
             unit, many=False, context={"srid": srid, "latlon": latlon}
         )
@@ -103,7 +99,6 @@ class MobileUnitGroupViewSet(viewsets.ReadOnlyModelViewSet):
             serializer_class = MobileUnitGroupUnitsSerializer
         else:
             serializer_class = MobileUnitGroupSerializer
-
         serializer = serializer_class(
             page, many=True, context={"srid": srid, "latlon": latlon}
         )

--- a/mobility_data/importers/payment_zones.py
+++ b/mobility_data/importers/payment_zones.py
@@ -18,7 +18,7 @@ SOURCE_DATA_SRID = 3877
 
 
 class PaymentZone:
-    # This are the names of the data fields in the source data.
+    # These are the names of the data fields in the source data.
     FIELDS = [
         "Lisatieto",
         "maksullisuus_arki",

--- a/mobility_data/importers/payment_zones.py
+++ b/mobility_data/importers/payment_zones.py
@@ -1,0 +1,81 @@
+import logging
+
+from django import db
+from django.conf import settings
+from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.geos import Polygon
+
+from mobility_data.models import ContentType, MobileUnit
+
+from .utils import delete_mobile_units, get_or_create_content_type
+
+logger = logging.getLogger("mobility_data")
+PAYMENT_ZONES_URL = "".format(
+    settings.TURKU_WFS_URL,
+    "service=WFS&request=GetFeature&typeName=GIS:Pysakoinnin_maksuvyohykkeet&outputFormat=GML3",
+)
+SOURCE_DATA_SRID = 3877
+
+
+class PaymentZone:
+    # This are the names of the data fields in the source data.
+    FIELDS = [
+        "Lisatieto",
+        "maksullisuus_arki",
+        "maksullisuus_lauantai",
+        "maksullisuus_sunnuntai",
+        "maksuvyohyke",
+        "maksuvyohykehinta",
+        "paatosdiaari",
+        "paatospykala",
+    ]
+    geometry = None
+
+    def __init__(self, feature):
+        for field in self.FIELDS:
+            setattr(self, field, feature[field].as_string())
+        polygon = Polygon(feature.geom.coords[0], srid=SOURCE_DATA_SRID)
+        polygon.transform(settings.DEFAULT_SRID)
+        self.geometry = polygon
+
+
+def get_payment_zone_objects():
+    ds = DataSource(PAYMENT_ZONES_URL)
+    layer = ds[0]
+    payment_zones = []
+    for feature in layer:
+        payment_zones.append(PaymentZone(feature))
+    return payment_zones
+
+
+@db.transaction.atomic
+def delete_payment_zones():
+    delete_mobile_units(ContentType.PAYMENT_ZONE)
+
+
+@db.transaction.atomic
+def create_payment_zone_content_type():
+    description = "Payment zones In the region of Turku"
+    name = "Payment Zones"
+    content_type, _ = get_or_create_content_type(
+        ContentType.PAYMENT_ZONE, name, description
+    )
+    return content_type
+
+
+@db.transaction.atomic
+def save_to_database(objects, delete_tables=True):
+    if delete_tables:
+        delete_payment_zones()
+
+    content_type = create_payment_zone_content_type()
+    for object in objects:
+        mobile_unit = MobileUnit.objects.create(
+            content_type=content_type,
+        )
+        extra = {}
+        for field in PaymentZone.FIELDS:
+            extra[field] = getattr(object, field, None)
+        mobile_unit.extra = extra
+        mobile_unit.geometry = object.geometry
+        mobile_unit.save()

--- a/mobility_data/importers/payment_zones.py
+++ b/mobility_data/importers/payment_zones.py
@@ -10,9 +10,9 @@ from mobility_data.models import ContentType, MobileUnit
 from .utils import delete_mobile_units, get_or_create_content_type
 
 logger = logging.getLogger("mobility_data")
-PAYMENT_ZONES_URL = "".format(
+PAYMENT_ZONES_URL = "{}{}".format(
     settings.TURKU_WFS_URL,
-    "service=WFS&request=GetFeature&typeName=GIS:Pysakoinnin_maksuvyohykkeet&outputFormat=GML3",
+    "?service=WFS&request=GetFeature&typeName=GIS:Pysakoinnin_maksuvyohykkeet&outputFormat=GML3",
 )
 SOURCE_DATA_SRID = 3877
 

--- a/mobility_data/management/commands/import_payment_zones.py
+++ b/mobility_data/management/commands/import_payment_zones.py
@@ -1,0 +1,18 @@
+import logging
+
+from django.core.management import BaseCommand
+
+from mobility_data.importers.payment_zones import (
+    get_payment_zone_objects,
+    save_to_database,
+)
+
+logger = logging.getLogger("mobility_data")
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        logger.info("Importing payment zones.")
+        objects = get_payment_zone_objects()
+        save_to_database(objects)
+        logger.info(f"Saved {len(objects)} payment zones.")

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -5,3 +5,8 @@ from django.core import management
 @shared_task
 def import_culture_routes(args, name="import_culture_routes"):
     management.call_command("import_culture_routes", args)
+
+
+@shared_task
+def import_payments_zones(name="import_payment_zones"):
+    management.call_command("import_payment_zones")


### PR DESCRIPTION
# Importer for payment zones

## Description
Imports the information and geometry of payment zones to mobility_data.  

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importer
 1. mobility_data/importers/payment_zones.py
     * Importer for the payment zones. Fetches/processes data using GDAL DataSource from Turku WFS server and stores to database.   
 2. mobility_data/management/commands/import_payment_zones.py
     * Management command to import the payment zones.    
 3. mobility_data/tasks.py
     * Celery task that runs the payment zones importer.
     
#### Api
 1. mobility_data/api/serializers/mobile_unit.py 
     * Now serializes polygons   
 2. mobility_data/api/views.py
     * Now "latlon" is assigned True/False instead of 1/0. Which caused unwanted behavior when comparing with "is True" etc.
 