### PR TITLE
Feature/bicycle stands more convenient names

### DIFF
--- a/mobility_data/importers/bicycle_stands.py
+++ b/mobility_data/importers/bicycle_stands.py
@@ -16,10 +16,13 @@ from .utils import (
     set_translated_field,
 )
 
+FI_KEY = "fi"
+SV_KEY = "sv"
+EN_KEY = "en"
 NAME_PREFIX = {
-    "fi": "Pyöräpysäköinti",
-    "sv": "Cykelparkering",
-    "en": "Bicycle parking",
+    FI_KEY: "Pyöräpysäköinti",
+    SV_KEY: "Cykelparkering",
+    EN_KEY: "Bicycle parking",
 }
 BICYCLE_STANDS_URL = "{}{}".format(
     settings.TURKU_WFS_URL,
@@ -123,9 +126,9 @@ class BicyleStand:
             self.name = full_names
         # Finnish name in source data, assign closest address full names to "sv" and "en" names.
         else:
-            self.name["fi"] = name
-            self.name["sv"] = full_names["sv"]
-            self.name["en"] = full_names["en"]
+            self.name[FI_KEY] = name
+            self.name[SV_KEY] = full_names[SV_KEY]
+            self.name[EN_KEY] = full_names[EN_KEY]
         self.prefix_name = {k: f"{NAME_PREFIX[k]} {v}" for k, v in self.name.items()}
 
 

--- a/smbackend_turku/importers/bicycle_stands.py
+++ b/smbackend_turku/importers/bicycle_stands.py
@@ -1,31 +1,27 @@
 from datetime import datetime
+
 from django.conf import settings
-from mobility_data.models import content_type
-from services.models import (
-    Service,
-    ServiceNode,
-    Unit,
-    UnitServiceDetails,
+
+from mobility_data.importers.bicycle_stands import (
+    create_bicycle_stand_content_type,
+    delete_bicycle_stands,
+    get_bicycle_stand_objects,
 )
+from mobility_data.importers.utils import create_mobile_unit_as_unit_reference
 from services.management.commands.services_import.services import (
     update_service_node_counts,
 )
+from services.models import Service, ServiceNode, Unit, UnitServiceDetails
 from smbackend_turku.importers.utils import (
-    set_field,
-    set_tku_translated_field,
-    set_syncher_object_field,
-    set_service_names_field,
     create_service,
     create_service_node,
     get_municipality,
+    set_field,
+    set_service_names_field,
+    set_syncher_object_field,
+    set_tku_translated_field,
     UTC_TIMEZONE,
 )
-from mobility_data.importers.bicycle_stands import (
-    get_bicycle_stand_objects,
-    delete_bicycle_stands,
-    create_bicycle_stand_content_type,
-)
-from mobility_data.importers.utils import create_mobile_unit_as_unit_reference
 
 
 class BicycleStandImporter:
@@ -67,7 +63,7 @@ class BicycleStandImporter:
             unit_id = i + self.UNITS_ID_OFFSET
             obj = Unit(id=unit_id)
             set_field(obj, "location", data_obj.geometry)
-            set_tku_translated_field(obj, "name", data_obj.name)
+            set_tku_translated_field(obj, "name", data_obj.prefix_name)
             set_tku_translated_field(obj, "street_address", data_obj.name)
             extra = {}
             extra["model"] = data_obj.model


### PR DESCRIPTION
# More convenient names to bicycle parkings

## Description
Names are now prefixed with "Bicycle parking" and if no name is found in source the full address is given as name. 
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importers
 1. mobility_data/importers/bicycle_stands.py
     * Generates the name with prefix and full address if no name is found.
   
 2. mobility_data/importers/utils.py
     * Added function to get the closest address and the multilingual full names of the address
    
 3. smbackend_turku/importers/bicycle_stands.py
     * Set the prefixed name to the Units that are shown in the service list. 

