### PR TITLE
Update django version to >=4.0.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django>=4.0.2
+Django>=4.0.4
 djangorestframework
 djangorestframework-jsonp
 Markdown
@@ -37,3 +37,4 @@ celery
 git+https://github.com/celery/django-celery-beat.git#fa73034be892052893e4ef17926ef3a5d4a21ea2
 django-celery-results
 redis
+libvoikko

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ coverage==5.5
     # via pytest-cov
 deprecated==1.2.13
     # via redis
-django==4.0.2
+django==4.0.4
     # via
     #   -r requirements.in
     #   django-celery-beat
@@ -109,6 +109,8 @@ jedi==0.18.0
     # via -r requirements.in
 kombu==5.2.3
     # via celery
+libvoikko==4.3
+    # via -r requirements.in
 lxml==4.8.0
     # via
     #   -r requirements.in
@@ -193,9 +195,7 @@ requests==2.26.0
     #   requests-cache
     #   requests-mock
 requests-cache==0.8.1
-    # via
-    #   -r requirements.in
-    #   django-munigeo
+    # via -r requirements.in
 requests-mock==1.9.3
     # via -r requirements.in
 shapely==1.8.0


### PR DESCRIPTION
#  Fixes for dependabot alerts

## Description
fix for:
SQL Injection in Django #9
SQL Injection in Django #8


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Requirements
 1. requirements.in    
 2. requirements.txt
     * Update django version to >=4.0.4
    
 