### PR TITLE
Feature/bicycle stands remove if name duplicate and fix tests

### DIFF
--- a/mobility_data/tests/conftest.py
+++ b/mobility_data/tests/conftest.py
@@ -121,7 +121,7 @@ def streets():
     street = Street.objects.create(
         name="Linnanpuisto",
         name_fi="Linnanpuisto",
-        name_sv="LinnanpuistoSV",
+        name_sv="Slottsparken",
         municipality_id="turku",
     )
     streets.append(street)
@@ -132,22 +132,56 @@ def streets():
         municipality_id="turku",
     )
     streets.append(street)
+    street = Street.objects.create(
+        name="Pitkäpellonkatu",
+        name_fi="Pitkäpellonkatu",
+        name_sv="Långåkersgatan",
+        municipality_id="turku",
+    )
+    streets.append(street)
     return streets
 
 
 @pytest.mark.django_db
 @pytest.fixture
 def address(streets):
-    location = Point(22.244, 60.444, srid=3877)
+    addresses = []
+    location = Point(22.244, 60.4, srid=4326)
     address = Address.objects.create(
-        id=100, location=location, street=streets[0], number=42
+        id=100,
+        location=location,
+        street=streets[0],
+        number=42,
+        full_name_fi="Test Street 42",
+        full_name_sv="Test StreetSV 42",
     )
-    location = Point(22.241, 60.333, srid=3877)
+    addresses.append(address)
+    location = Point(22.2265, 60.43504, srid=4326)
     address = Address.objects.create(
-        id=101, location=location, street=streets[1], number=24
+        id=101,
+        location=location,
+        street=streets[1],
+        full_name_fi="Linnanpuisto",
+        full_name_sv="Slottsparken",
     )
-    location = Point(22.241, 60.333, srid=3877)
+    addresses.append(address)
+    location = Point(22.264457, 60.448905, srid=4326)
     address = Address.objects.create(
-        id=102, location=location, street=streets[2], number=24
+        id=102,
+        location=location,
+        street=streets[2],
+        number=4,
+        full_name_fi="Kristiinankatu 4",
+        full_name_sv="Kristinegata 4",
     )
-    return address
+    addresses.append(address)
+    location = Point(22.2383, 60.411726, srid=4326)
+    address = Address.objects.create(
+        id=103,
+        location=location,
+        street=streets[3],
+        number=7,
+        full_name_fi="Pitkäpellonkatu 7",
+        full_name_sv="Långåkersgatan 7",
+    )
+    return addresses

--- a/mobility_data/tests/test_import_bicycle_stands.py
+++ b/mobility_data/tests/test_import_bicycle_stands.py
@@ -27,7 +27,7 @@ def test_importer(
     streets,
     address,
 ):
-    out = import_command(test_mode="bicycle_stands.xml")
+    import_command(test_mode="bicycle_stands.xml")
     assert MobileUnit.objects.all().count() == 3
     # <GIS:Id>0</GIS:Id> in fixture xml.
     stand_normal = MobileUnit.objects.all()[0]
@@ -35,10 +35,8 @@ def test_importer(
     stand_covered_hull_lockable = MobileUnit.objects.all()[1]
     # <GIS:Id>319490982</GIS:Id> in fixture xml
     stand_external = MobileUnit.objects.all()[2]
-
     assert stand_normal.name_fi == "Linnanpuisto"
-    assert stand_normal.name_sv == "LinnanpuistoSV"
-    assert stand_normal.name_en == "Linnanpuisto"
+    assert stand_normal.name_sv == "Slottsparken"
     extra = stand_normal.extra
     assert extra["model"] == "Normaali"
     assert extra["maintained_by_turku"] is True
@@ -47,17 +45,18 @@ def test_importer(
     assert extra["number_of_places"] == 24
     assert extra["number_of_stands"] == 2
     assert extra["number_of_stands"] == 2
-
     assert stand_covered_hull_lockable.name == "Pitkäpellonkatu"
+    assert stand_covered_hull_lockable.name_sv == "Långåkersgatan 7"
     extra = stand_covered_hull_lockable.extra
     assert extra["maintained_by_turku"] is True
     assert extra["covered"] is True
     assert extra["hull_lockable"] is True
     assert extra["number_of_places"] == 18
     assert extra["number_of_stands"] == 1
-    # external stand has no street name, so the closes street name
-    # is "Test Street".
-    assert stand_external.name == "Test Street"
+    # external stand has no street name, so the closest street name
+    # and address number is assigned as name and that is "Test Street 42".
+    assert stand_external.name == "Test Street 42"
+    assert stand_external.name_sv == "Test StreetSV 42"
     extra = stand_external.extra
     assert extra["maintained_by_turku"] is False
     # As there are no info for stand that are not maintained by turku

--- a/mobility_data/tests/test_import_bicycle_stands.py
+++ b/mobility_data/tests/test_import_bicycle_stands.py
@@ -45,7 +45,7 @@ def test_importer(
     assert extra["number_of_places"] == 24
     assert extra["number_of_stands"] == 2
     assert extra["number_of_stands"] == 2
-    assert stand_covered_hull_lockable.name == "Pitkäpellonkatu"
+    assert stand_covered_hull_lockable.name == "Pitkäpellonkatu 7"
     assert stand_covered_hull_lockable.name_sv == "Långåkersgatan 7"
     extra = stand_covered_hull_lockable.extra
     assert extra["maintained_by_turku"] is True

--- a/smbackend_turku/importers/bicycle_stands.py
+++ b/smbackend_turku/importers/bicycle_stands.py
@@ -72,6 +72,11 @@ class BicycleStandImporter:
             extra["number_of_places"] = data_obj.number_of_places
             extra["hull_lockable"] = data_obj.hull_lockable
             extra["covered"] = data_obj.covered
+            # Add non prefixed names to extra, so that the front end does not need
+            # to remove the prefix.
+            extra["name_fi"] = data_obj.name["fi"]
+            extra["name_sv"] = data_obj.name["sv"]
+            extra["name_en"] = data_obj.name["en"]
             set_field(obj, "extra", extra)
             if data_obj.maintained_by_turku:
                 # 1 = self produced


### PR DESCRIPTION
# Remove duplicate names if not maintained by Turku, name is now assigned the closest street + number, fixed tests



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importers
 1. mobility_data/importers/bicycle_stands.py
     * Name  ends now with Street name + number. Removes bicycle stands that are not maintained by Turku and points to already existing address in names to reduce the amount of duplicate names.
   
 2.  smbackend_turku/importers/bicycle_stands.py
     * Add non prefixed name to extra, the front end can read it from there and does not have to do string manipulation.
    
     
#### Tests
 1. mobility_data/tests/conftest.py
     * Added/modified Street and Address fixtures
   
 2. mobility_data/tests/test_import_bicycle_stands.py
     * Modified name testing to reflect the changes in importer
 