### PR TITLE
Feature/possibility to delete separately external sources

### DIFF
--- a/smbackend_turku/README.md
+++ b/smbackend_turku/README.md
@@ -58,9 +58,15 @@ To delete all data imported from external sources:
 ```
 ./manage.py turku_services_import services units --delete-external-sources
 ```
+
+To delete a specific imported external data source:
+e.g. remove bicycle_stands
+```
+./manage.py turku_services_import bicycle_stands --delete-external-source
+```
 Currently following importers import to the mobility view by setting
 a id, which is used to retrieve the data from the service_unit table:
-gas_filling_stations, charging_stations and bicycle_stands. e.g. These
+gas_filling_stations and bicycle_stands. e.g. These
 importers import data to both the services list and mobility view.
 
 When importing services and units the ids are received from the source. Therefore the ids for the external sources must be manually set to avoid id collisions. 
@@ -80,14 +86,6 @@ To import type:
 ./manage.py turku_services_import gas_filling_stations
 ```
 
-### Charging stations
-Add following line to the .env file:
-CHARGING_STATIONS_IDS=service_node=300000,service=300000,units_offset=300000
-
-To import type:
-```
-./manage.py turku_services_import charging_stations
-```
 ### Bicycle stands
 Add following line to the .env file:
 BICYCLE_STANDS_IDS=service_node=400000,service=400000,units_offset=400000

--- a/smbackend_turku/tasks.py
+++ b/smbackend_turku/tasks.py
@@ -8,6 +8,11 @@ def turku_services_import(args, name="turku_services_import"):
 
 
 @shared_task
+def delete_external_source(source, name="delete_external_source"):
+    management.call_command("turku_services_import", source, "--delete-external-source")
+
+
+@shared_task
 def import_mds_data(name="import_mds_data"):
     management.call_command(
         "turku_services_import", "services", "accessibility", "units"


### PR DESCRIPTION
# Possibility to delete separately external sources, via management command or using Celery task


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importers
 1. smbackend_turku/importers/bicycle_stands.py
     * Added function that deletes the bicycle_stands.
   
 2. smbackend_turku/importers/stations.py
     * Added function that deletes gas_filling_stations.
    
 3. smbackend_turku/importers/utils.py
     * Added function that deletes the Units, Service, ServiceNode and optionally mobility_data of a source.
4. smbackend_turku/importers/utils.py
    * Added parameter --delete-external source, if given deletes the source(s) given as argument.     

#### Other 
 1. smbackend_turku/README.md
     * Added info about how to delete separately a source. Delete charging_station info as it is obsolete.
   
 2. smbackend_turku/tasks.py
     * Task for deleting separately external source.
    
 
