### PR TITLE
Feature/scooter restrictions importer

### DIFF
--- a/mobility_data/README.md
+++ b/mobility_data/README.md
@@ -43,3 +43,10 @@ To import data type:
 ```
 ./manage.py import_payment_zones
 ```
+
+### Scooter Restriction
+Imports parking, no parking and speed limit zones.
+To import data type:
+```
+./manage.py import_scooter_restrictions
+```

--- a/mobility_data/importers/scooter_restrictions.py
+++ b/mobility_data/importers/scooter_restrictions.py
@@ -17,7 +17,7 @@ SPEED_LIMIT_URL = "{}{}".format(
     settings.TURKU_WFS_URL,
     "?service=WFS&request=GetFeature&typeName=GIS:Sahkopotkulauta_nopeusrajoitus&outputFormat=GML3",
 )
-NO_PARKING_ZONE = "{}{}".format(
+NO_PARKING_ZONE_URL = "{}{}".format(
     settings.TURKU_WFS_URL,
     "?service=WFS&request=GetFeature&typeName=GIS:Sahkopotkulauta_pysakointikielto&outputFormat=GML3",
 )
@@ -100,7 +100,7 @@ def get_scooter_restriction_elements():
             "content_type_create_func": create_scooter_speed_limit_content_type,
         },
         "No Parking": {
-            "url": NO_PARKING_ZONE,
+            "url": NO_PARKING_ZONE_URL,
             "content_type": ContentType.SCOOTER_NO_PARKING,
             "content_type_create_func": create_scooter_speed_no_parking_content_type,
         },

--- a/mobility_data/importers/scooter_restrictions.py
+++ b/mobility_data/importers/scooter_restrictions.py
@@ -1,0 +1,107 @@
+import logging
+
+from django import db
+from django.conf import settings
+from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.geos import GEOSGeometry
+
+from mobility_data.models import ContentType, MobileUnit
+
+from .utils import delete_mobile_units, get_or_create_content_type
+
+PARKING_ZONE_URL = "{}{}".format(
+    settings.TURKU_WFS_URL,
+    "?service=WFS&request=GetFeature&typeName=GIS:Sahkopotkulautaparkki&outputFormat=GML3",
+)
+SPEED_LIMIT_URL = "{}{}".format(
+    settings.TURKU_WFS_URL,
+    "?service=WFS&request=GetFeature&typeName=GIS:Sahkopotkulauta_nopeusrajoitus&outputFormat=GML3",
+)
+NO_PARKING_ZONE = "{}{}".format(
+    settings.TURKU_WFS_URL,
+    "?service=WFS&request=GetFeature&typeName=GIS:Sahkopotkulauta_pysakointikielto&outputFormat=GML3",
+)
+
+
+SOURCE_DATA_SRID = 3877
+logger = logging.getLogger("mobility_data")
+
+
+class ScooterRestriction:
+    def __init__(self, feature):
+        self.geometry = GEOSGeometry(feature.geom.wkt, srid=SOURCE_DATA_SRID)
+        self.geometry.transform(settings.DEFAULT_SRID)
+
+
+def get_datasource_layer(url):
+    ds = DataSource(url)
+    layer = ds[0]
+    return layer
+
+
+def get_restriction_objects(layer):
+    objects = []
+    for feature in layer:
+        objects.append(ScooterRestriction(feature))
+    return objects
+
+
+@db.transaction.atomic
+def create_scooter_parking_content_type():
+    description = "Scooter parking zones in the Turku region."
+    name = "Scooter parking"
+    content_type, _ = get_or_create_content_type(
+        ContentType.SCOOTER_PARKING, name, description
+    )
+    return content_type
+
+
+@db.transaction.atomic
+def create_scooter_speed_limit_content_type():
+    description = "Scooter speed limit zones in the Turku region."
+    name = "Scooter speed limit"
+    content_type, _ = get_or_create_content_type(
+        ContentType.SCOOTER_SPEED_LIMIT, name, description
+    )
+    return content_type
+
+
+@db.transaction.atomic
+def create_scooter_speed_no_parking_content_type():
+    description = "Scooter no parking zones in the Turku region."
+    name = "Scooter no parking"
+    content_type, _ = get_or_create_content_type(
+        ContentType.SCOOTER_NO_PARKING, name, description
+    )
+    return content_type
+
+
+@db.transaction.atomic
+def save_to_database(objects, create_content_type_func, content_type_str, delete=True):
+    if delete:
+        delete_mobile_units(content_type_str)
+    content_type = create_content_type_func()
+    for object in objects:
+        mobile_unit = MobileUnit.objects.create(content_type=content_type)
+        mobile_unit.geometry = object.geometry
+        mobile_unit.save()
+
+
+def get_scooter_restriction_elements():
+    return {
+        "Parking": {
+            "url": PARKING_ZONE_URL,
+            "content_type": ContentType.SCOOTER_PARKING,
+            "content_type_create_func": create_scooter_parking_content_type,
+        },
+        "Speed Limit": {
+            "url": SPEED_LIMIT_URL,
+            "content_type": ContentType.SCOOTER_SPEED_LIMIT,
+            "content_type_create_func": create_scooter_speed_limit_content_type,
+        },
+        "No Parking": {
+            "url": NO_PARKING_ZONE,
+            "content_type": ContentType.SCOOTER_NO_PARKING,
+            "content_type_create_func": create_scooter_speed_no_parking_content_type,
+        },
+    }

--- a/mobility_data/management/commands/import_mobility_data.py
+++ b/mobility_data/management/commands/import_mobility_data.py
@@ -12,6 +12,7 @@ importers = [
     "gas_filling_stations",
     "bicycle_stands",
     "payment_zones",
+    "scooter_restrictions",
 ]
 logger = logging.getLogger("mobility_data")
 

--- a/mobility_data/management/commands/import_scooter_restrictions.py
+++ b/mobility_data/management/commands/import_scooter_restrictions.py
@@ -1,0 +1,23 @@
+import logging
+
+from django.core.management import BaseCommand
+from mobility_data.importers.scooter_restrictions import (
+    get_datasource_layer,
+    get_restriction_objects,
+    get_scooter_restriction_elements,
+    save_to_database,
+)
+
+logger = logging.getLogger("mobility_data")
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        logger.info("Importing Scooter restrictions.")
+        for key, value in get_scooter_restriction_elements().items():
+            layer = get_datasource_layer(value["url"])
+            objects = get_restriction_objects(layer)
+            save_to_database(
+                objects, value["content_type_create_func"], value["content_type"]
+            )
+            logger.info(f"Imported {len(objects)} {key} objects.")

--- a/mobility_data/models/content_type.py
+++ b/mobility_data/models/content_type.py
@@ -31,6 +31,9 @@ class ContentType(BaseType):
     CULTURE_ROUTE_GEOMETRY = "CRG"
     BICYCLE_STAND = "BIS"
     PAYMENT_ZONE = "PAZ"
+    SCOOTER_PARKING = "SPG"
+    SCOOTER_SPEED_LIMIT = "SSL"
+    SCOOTER_NO_PARKING = "SNP"
     CONTENT_TYPES = [
         (CHARGING_STATION, "ChargingStation"),
         (GAS_FILLING_STATION, "GasFillingStation"),
@@ -38,6 +41,9 @@ class ContentType(BaseType):
         (CULTURE_ROUTE_GEOMETRY, "CultureRouteGeometry"),
         (BICYCLE_STAND, "BicycleStand"),
         (PAYMENT_ZONE, "PaymentZone"),
+        (SCOOTER_PARKING, "ScooterParking"),
+        (SCOOTER_SPEED_LIMIT, "ScooterSpeedLimit"),
+        (SCOOTER_NO_PARKING, "ScooterNoParking"),
     ]
     type_name = models.CharField(max_length=3, choices=CONTENT_TYPES, null=True)
 

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -10,3 +10,8 @@ def import_culture_routes(args, name="import_culture_routes"):
 @shared_task
 def import_payments_zones(name="import_payment_zones"):
     management.call_command("import_payment_zones")
+
+
+@shared_task
+def import_mobility_data(name="import_mobility_data"):
+    management.call_command("import_mobilitiy_data")

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -19,4 +19,4 @@ def import_scooter_restrictions(name="import_scooter_restrictions"):
 
 @shared_task
 def import_mobility_data(name="import_mobility_data"):
-    management.call_command("import_mobilitiy_data")
+    management.call_command("import_mobility_data")

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -13,5 +13,10 @@ def import_payments_zones(name="import_payment_zones"):
 
 
 @shared_task
+def import_scooter_restrictions(name="import_scooter_restrictions"):
+    management.call_command("import_scooter_restrictions")
+
+
+@shared_task
 def import_mobility_data(name="import_mobility_data"):
     management.call_command("import_mobilitiy_data")


### PR DESCRIPTION
# Importer for scooter restrictions

## Description
Import parking, no parking and speed limit zones for scooters

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importers
1. mobility_data/management/commands/import_mobility_data.py
    * Added scooter restrictions.
2. mobility_data/management/commands/import_scooter_restrictions.py
    * Management command that imports the scooter restriction.
3. mobility_data/importers/scooter_restrictions.py
    * Importer for the scooter restrictions.


####  Models
1. mobility_data/models/content_type.py
    * Added content types for scooter restrictions.
#### Docs
1. mobility_data/README.md
    * Added info of how to import scooter restrictions  .
#### Celery Task
1. mobility_data/tasks.py
    * Added task to import scooter restrictions and all mobility data sources.
