### PR TITLE
Bugfix/fix typos in pr58

### DIFF
--- a/services/management/commands/index_search_columns.py
+++ b/services/management/commands/index_search_columns.py
@@ -40,7 +40,7 @@ def generate_syllables(model):
             row_content = getattr(row, column, None)
             if row_content:
                 # Rows migth be of type str or Array, if str
-                # cast to array by spliting.
+                # cast to array by splitting.
                 if isinstance(row_content, str):
                     row_content = row_content.split()
                 for word in row_content:
@@ -96,7 +96,7 @@ class Command(BaseCommand):
                     f"Syllables generated for {generate_syllables(Service)} Services"
                 )
                 logger.info(
-                    f"Syllables generated for {generate_syllables(ServiceNode)} ServoceNodes"
+                    f"Syllables generated for {generate_syllables(ServiceNode)} ServiceNodes"
                 )
 
             logger.info(

--- a/services/models/service.py
+++ b/services/models/service.py
@@ -49,7 +49,7 @@ class Service(models.Model):
         Defines the columns that will be used when populating
         finnish syllables to syllables_fi column. The content 
         will be tokenized to lexems(to_tsvector) and added to 
-        the the search_column.
+        the search_column.
         """
         return [
             "name_fi",     

--- a/services/models/service_node.py
+++ b/services/models/service_node.py
@@ -93,7 +93,7 @@ class ServiceNode(MPTTModel):
         Defines the columns that will be used when populating
         finnish syllables to syllables_fi column. The content
         will be tokenized to lexems(to_tsvector) and added to
-        the the search_column.
+        the search_column.
         """
         return [
             "name_fi",

--- a/services/models/unit.py
+++ b/services/models/unit.py
@@ -278,7 +278,7 @@ class Unit(SoftDeleteModel):
         Defines the columns that will be used when populating
         finnish syllables to syllables_fi column. The content
         will be tokenized to lexems(to_tsvector) and added to
-        the the search_column.
+        the search_column.
         """
         return ["name_fi", "service_names_fi"]
 


### PR DESCRIPTION
# Fixes typos in comments found in PR #58


### Breakdown:

#### Fixed typos
1. services/management/commands/index_search_columns.py
    * Spliting->splitting, ServoceNode->ServiceNode
2. services/models/service.py
3. services/models/service_node.py
4. services/models/unit.py
    * Removed the duplicate "the" from comments.
   


