### PR TITLE
Feature/speed limit zones importer

### DIFF
--- a/mobility_data/README.md
+++ b/mobility_data/README.md
@@ -7,6 +7,9 @@ TURKU_WFS_URL=https://opaskartta.turku.fi/TeklaOGCWeb/WFS.ashx
 ```
 
 ## importers
+It is recommended to use Celery tasks to import the mobility data,
+see: https://github.com/City-of-Turku/smbackend/wiki/Celery-Tasks
+
 To import all data sources:
 ```
 ./manage.py import_mobility_data
@@ -42,4 +45,9 @@ To import data type:
 To import data type:
 ```
 ./manage.py import_payment_zones
+```
+### Speed limit Zones
+To import type:
+```
+./manage.py import_speed_limit_zones
 ```

--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -1,5 +1,11 @@
 from django.contrib.gis.gdal.error import GDALException
-from django.contrib.gis.geos import GEOSGeometry, LineString, Point, Polygon
+from django.contrib.gis.geos import (
+    GEOSGeometry,
+    LineString,
+    MultiPolygon,
+    Point,
+    Polygon,
+)
 from rest_framework import serializers
 
 from services.models import Unit
@@ -119,6 +125,21 @@ class MobileUnitSerializer(serializers.ModelSerializer):
                     # swap lon,lat -> lat lon
                     e = (coord[1], coord[0])
                     coords.append(e)
+                return coords
+            else:
+                return geometry.coords
+        elif isinstance(geometry, MultiPolygon):
+            if self.context["latlon"] is True:
+                coords = []
+                # Iterate through all the polygons in the multipolygon
+                # Create a list of swapped coords for every polygon
+                for polygon in geometry.coords:
+                    polygon_coords = []
+                    for p_c in list(*polygon):
+                        # swap lon,lat -> lat lon
+                        e = (p_c[1], p_c[0])
+                        polygon_coords.append(e)
+                    coords.append(polygon_coords)
                 return coords
             else:
                 return geometry.coords

--- a/mobility_data/importers/speed_limits.py
+++ b/mobility_data/importers/speed_limits.py
@@ -1,0 +1,81 @@
+import logging
+
+from django import db
+from django.conf import settings
+from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
+
+from mobility_data.importers.utils import (
+    delete_mobile_units,
+    get_or_create_content_type,
+)
+from mobility_data.models import ContentType
+from mobility_data.models.mobile_unit import MobileUnit
+
+logger = logging.getLogger("mobility_data")
+
+SOURCE_DATA_SRID = 3877
+
+SPEED_LIMITS_URL = "{}{}".format(
+    settings.TURKU_WFS_URL,
+    "?service=WFS&request=GetFeature&typeName=GIS:Nopeusrajoitusalueet&outputFormat=GML3",
+)
+
+
+class SpeedLimit:
+    def __init__(self, feature):
+        """
+        The source data contains also polygons that marks areas inside the
+        speed limit polygon that are not affected by the limit. This is made
+        into a multipolygon where the first polygon is the speed limit itself
+        and the rest of the polygons marks areas that are not affected by the
+        speed limit.
+        """
+        if len(feature.geom.coords) > 1:
+            polygons = []
+            for coords in feature.geom.coords:
+                polygons.append(Polygon(coords, srid=SOURCE_DATA_SRID))
+            self.geometry = MultiPolygon(polygons, srid=SOURCE_DATA_SRID)
+        else:
+            self.geometry = GEOSGeometry(feature.geom.wkt, srid=SOURCE_DATA_SRID)
+        self.geometry.transform(settings.DEFAULT_SRID)
+        self.speed_limit = feature["Nopeus"].as_int()
+
+
+def get_speed_limit_objects():
+    ds = DataSource(SPEED_LIMITS_URL)
+    layer = ds[0]
+    objects = []
+    for feature in layer:
+        objects.append(SpeedLimit(feature))
+    return objects
+
+
+@db.transaction.atomic
+def create_speed_limit_content_type():
+    description = "Speed limit zones in the Turku region."
+    name = "Speed limit zones"
+    content_type, _ = get_or_create_content_type(
+        ContentType.SPEED_LIMIT_ZONE, name, description
+    )
+    return content_type
+
+
+@db.transaction.atomic
+def delete_speed_limit_zones():
+    delete_mobile_units(ContentType.SPEED_LIMIT_ZONE)
+
+
+@db.transaction.atomic
+def save_to_database(objects, delete_tables=True):
+    if delete_tables:
+        delete_speed_limit_zones()
+    content_type = create_speed_limit_content_type()
+    for object in objects:
+        mobile_unit = MobileUnit.objects.create(
+            content_type=content_type,
+        )
+        extra = {"speed_limit": object.speed_limit}
+        mobile_unit.geometry = object.geometry
+        mobile_unit.extra = extra
+        mobile_unit.save()

--- a/mobility_data/management/commands/import_mobility_data.py
+++ b/mobility_data/management/commands/import_mobility_data.py
@@ -12,6 +12,7 @@ importers = [
     "gas_filling_stations",
     "bicycle_stands",
     "payment_zones",
+    "speed_limit_zones",
 ]
 logger = logging.getLogger("mobility_data")
 

--- a/mobility_data/management/commands/import_speed_limit_zones.py
+++ b/mobility_data/management/commands/import_speed_limit_zones.py
@@ -1,0 +1,18 @@
+import logging
+
+from django.core.management import BaseCommand
+
+from mobility_data.importers.speed_limits import (
+    get_speed_limit_objects,
+    save_to_database,
+)
+
+logger = logging.getLogger("mobility_data")
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        logger.info("Importing speed limit.")
+        objects = get_speed_limit_objects()
+        save_to_database(objects)
+        logger.info(f"Imported {len(objects)} speed limit zones.")

--- a/mobility_data/models/content_type.py
+++ b/mobility_data/models/content_type.py
@@ -31,6 +31,7 @@ class ContentType(BaseType):
     CULTURE_ROUTE_GEOMETRY = "CRG"
     BICYCLE_STAND = "BIS"
     PAYMENT_ZONE = "PAZ"
+    SPEED_LIMIT_ZONE = "SLZ"
     CONTENT_TYPES = [
         (CHARGING_STATION, "ChargingStation"),
         (GAS_FILLING_STATION, "GasFillingStation"),
@@ -38,6 +39,7 @@ class ContentType(BaseType):
         (CULTURE_ROUTE_GEOMETRY, "CultureRouteGeometry"),
         (BICYCLE_STAND, "BicycleStand"),
         (PAYMENT_ZONE, "PaymentZone"),
+        (SPEED_LIMIT_ZONE, "SpeedLimitZone"),
     ]
     type_name = models.CharField(max_length=3, choices=CONTENT_TYPES, null=True)
 

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -10,3 +10,8 @@ def import_culture_routes(args, name="import_culture_routes"):
 @shared_task
 def import_payments_zones(name="import_payment_zones"):
     management.call_command("import_payment_zones")
+
+
+@shared_task
+def import_speed_limit_zones(name="import_speed_limit_zones"):
+    management.call_command("import_speed_limit_zones")

--- a/smbackend_turku/README.md
+++ b/smbackend_turku/README.md
@@ -50,7 +50,7 @@ Note, if geo-search addresses are imported this might take ~45minutes.
 ## Importing external data sources
 
 Importing from external data sources should always be done after importing the services and units.
-To import the mobility data, currently imports: charging stations, gas filling stations and bicycle stands.
+To import the mobility data, currently imports: gas filling stations, bicycle stands, payment_zones, scooter_restrictions and speed_limit_zones
 ```
 ./manage.py turku_services_import mobility_data
 ```
@@ -94,3 +94,7 @@ To import type:
 ```
 ./manage.py turku_services_import bicycle_stands
 ```
+
+### Mobility data
+For detailed information about importing, see: /mobility_data/README.md
+


### PR DESCRIPTION
# Speed limit zones importer

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importer
1. mobility_data/importers/speed_limits.py
    * Importer for the speed limit zones.
2. mobility_data/management/commands/import_mobility_data.py
    * Management command for the importer.
3. mobility_data/management/commands/import_mobility_data.py
    * Added speed_limit_zones importer

#### Models
1. mobility_data/models/content_type.py
    * Content type for speed limit zones.

#### API
1. mobility_data/api/serializers/mobile_unit.py
    * Added Multipolygon serialization.

#### Tasks
1. mobility_data/tasks.py
   * Added task that imports the speed limit zones. 

#### Documentation
1. mobility_data/README.md
    * Added info about Celery and speed limit importer
2. smbackend_turku/README.md
    * Added mobility data
