### PR TITLE
Add query param maxFeatures=10000

### DIFF
--- a/mobility_data/importers/speed_limits.py
+++ b/mobility_data/importers/speed_limits.py
@@ -18,7 +18,7 @@ SOURCE_DATA_SRID = 3877
 
 SPEED_LIMITS_URL = "{}{}".format(
     settings.TURKU_WFS_URL,
-    "?service=WFS&request=GetFeature&typeName=GIS:Nopeusrajoitusalueet&outputFormat=GML3",
+    "?service=WFS&request=GetFeature&typeName=GIS:Nopeusrajoitusalueet&outputFormat=GML3&maxFeatures=10000",
 )
 
 


### PR DESCRIPTION
# Fixes bug, missing speed limit zones.


-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed 
1. mobility_data/importers/speed_limits.py
    * Added maxFeatures=10000 as query param to url that fetches from WFS, ensures all the speed limit zones will be fetched.

