### PR TITLE
Bug fix, old bike service stations not deleted during import

### DIFF
--- a/mobility_data/importers/bike_service_stations.py
+++ b/mobility_data/importers/bike_service_stations.py
@@ -95,7 +95,7 @@ def get_bike_service_station_objects(geojson_file=None):
 
 @db.transaction.atomic
 def delete_bike_service_stations():
-    delete_mobile_units(ContentType.BICYCLE_STAND)
+    delete_mobile_units(ContentType.BIKE_SERVICE_STATION)
 
 
 @db.transaction.atomic


### PR DESCRIPTION
# Bug fix, old bike service stations not deleted during import

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importer
 1. mobility_data/importers/bike_service_stations.py
     * Changed ContentType in delete to BIKE_SERVICE_STATION

   