### PR TITLE
Feature/update address importers and munigeo

### DIFF
--- a/mobility_data/tests/conftest.py
+++ b/mobility_data/tests/conftest.py
@@ -179,10 +179,11 @@ def streets():
 
 @pytest.mark.django_db
 @pytest.fixture
-def address(streets):
+def address(streets, municipality):
     addresses = []
     location = Point(22.244, 60.4, srid=4326)
     address = Address.objects.create(
+        municipality_id=municipality.id,
         id=100,
         location=location,
         street=streets[0],
@@ -193,6 +194,7 @@ def address(streets):
     addresses.append(address)
     location = Point(22.227168, 60.4350612, srid=4326)
     address = Address.objects.create(
+        municipality_id=municipality.id,
         id=101,
         location=location,
         street=streets[1],
@@ -202,6 +204,7 @@ def address(streets):
     addresses.append(address)
     location = Point(22.264457, 60.448905, srid=4326)
     address = Address.objects.create(
+        municipality_id=municipality.id,
         id=102,
         location=location,
         street=streets[2],
@@ -212,6 +215,7 @@ def address(streets):
     addresses.append(address)
     location = Point(22.2383, 60.411726, srid=4326)
     address = Address.objects.create(
+        municipality_id=municipality.id,
         id=103,
         location=location,
         street=streets[3],
@@ -222,6 +226,7 @@ def address(streets):
     addresses.append(address)
     location = Point(22.2871092678621, 60.44677715747775, srid=4326)
     address = Address.objects.create(
+        municipality_id=municipality.id,
         id=104,
         location=location,
         street=streets[4],
@@ -232,6 +237,7 @@ def address(streets):
     addresses.append(address)
     location = Point(22.26097246971352, 60.45055294118857, srid=4326)
     address = Address.objects.create(
+        municipality_id=municipality.id,
         id=105,
         location=location,
         street=streets[5],
@@ -242,6 +248,7 @@ def address(streets):
     addresses.append(address)
     location = Point(22.247047171564706, 60.45159033848499, srid=4326)
     address = Address.objects.create(
+        municipality_id=municipality.id,
         id=106,
         location=location,
         street=streets[6],

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ django-modeltranslation
 flake8
 requests
 requests_cache
-git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.69#egg=django-munigeo
+git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.72#egg=django-munigeo
 pytz
 django-cors-headers
 django-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ django-mptt==0.13.4
     # via
     #   -r requirements.in
     #   django-munigeo
-django-munigeo @ git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.69
+django-munigeo @ git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.72
     # via -r requirements.in
 django-polymorphic==3.1.0
     # via -r requirements.in

--- a/smbackend_turku/importers/addresses.py
+++ b/smbackend_turku/importers/addresses.py
@@ -130,6 +130,7 @@ class AddressImporter:
             full_name_fi = f"{name_fi} {number_letter}"
             full_name_sv = f"{name_sv} {number_letter}"
             entry["address"] = {}
+            entry["address"]["municipality_id"] = municipality.id
             entry["address"]["street"] = street
             entry["address"]["location"] = point
             entry["address"]["full_name_fi"] = full_name_fi

--- a/smbackend_turku/importers/geo_search.py
+++ b/smbackend_turku/importers/geo_search.py
@@ -250,6 +250,7 @@ class GeoSearchImporter:
             # Ensures that no duplicates goes to DB, as there are some in the source data
             if full_name_fi not in self.address_cache:
                 address = Address(
+                    municipality_id=municipality.id,
                     street=self.streets_cache[street_name_fi],
                     number=number,
                     number_end=number_end,
@@ -389,6 +390,7 @@ class GeoSearchImporter:
                 street_entry["name_sv"] = street_name_sv
 
             address_entry = {
+                "municipality_id": municipality.id,
                 "street": self.streets_cache[street_name_fi],
                 "number": result["number"],
                 "number_end": result["number_end"],

--- a/smbackend_turku/tests/conftest.py
+++ b/smbackend_turku/tests/conftest.py
@@ -75,10 +75,11 @@ def postal_code_areas():
 
 @pytest.mark.django_db
 @pytest.fixture
-def address(streets, postal_code_areas):
+def address(streets, postal_code_areas, municipality):
     addresses = []
     location = Point(22.26097246971352, 60.45055294118857, srid=4326)
     address = Address.objects.create(
+        municipality_id=municipality.id,
         id=105,
         postal_code_area_id=postal_code_areas[0].id,
         location=location,


### PR DESCRIPTION
# Update munigeo to version 2.72

## Description
This includes also a change in the munigeo model, that addresses has a relation to the municipality, so address importers where updated and test fixtures that creates addresses.
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importers
1. smbackend_turku/importers/addresses.py
2. smbackend_turku/importers/geo_search.py
    * Add municipality_id to addresses.
#### Requirements
1. requirements.in
4. requirements.txt
    * Change munigeo version to 2.72
#### Fixtures
1. mobility_data/tests/conftest.py
2. smbackend_turku/tests/conftest.py
   * Add municipality_id to address fixtures.