### PR TITLE
Feature/add mobility data target to turku services import

### DIFF
--- a/smbackend_turku/management/commands/turku_services_import.py
+++ b/smbackend_turku/management/commands/turku_services_import.py
@@ -33,6 +33,7 @@ from smbackend_turku.importers.units import import_units
 
 class Command(BaseCommand):
     help = "Import services from City of Turku APIs and from external sources."
+    MOBILITY_DATA = "mobility_data"
     external_sources = [
         "gas_filling_stations",
         "charging_stations",
@@ -47,6 +48,7 @@ class Command(BaseCommand):
         "addresses",
         "geo_search_addresses",
         "enriched_addresses",
+        MOBILITY_DATA,
     ] + external_sources
 
     supported_languages = [lang[0] for lang in settings.LANGUAGES]
@@ -195,9 +197,13 @@ class Command(BaseCommand):
             if not delete_count:
                 sys.stderr.write("Nothing to delete.\n")
         else:
+            if self.MOBILITY_DATA in self.options["import_types"]:
+                importers = self.external_sources
+            else:
+                importers = self.options["import_types"]
             import_count = 0
             for imp in self.importer_types:
-                if imp not in self.options["import_types"]:
+                if imp not in importers:
                     continue
                 method = getattr(self, "import_%s" % imp)
                 if self.verbosity:

--- a/smbackend_turku/management/commands/turku_services_import.py
+++ b/smbackend_turku/management/commands/turku_services_import.py
@@ -33,7 +33,10 @@ from smbackend_turku.importers.units import import_units
 
 class Command(BaseCommand):
     help = "Import services from City of Turku APIs and from external sources."
+
+    # Umbrella source that imports all external_sources
     MOBILITY_DATA = "mobility_data"
+
     external_sources = [
         "gas_filling_stations",
         "charging_stations",
@@ -197,10 +200,14 @@ class Command(BaseCommand):
             if not delete_count:
                 sys.stderr.write("Nothing to delete.\n")
         else:
+            importers = self.options["import_types"]
             if self.MOBILITY_DATA in self.options["import_types"]:
-                importers = self.external_sources
-            else:
-                importers = self.options["import_types"]
+                # Add external sources and by creating a set ensure there are no duplicates
+                # as the user can add args as mobility_data charging_stations
+                importers = set(importers + self.external_sources)
+                # remove the mobility_data source as it has no function attached to it.
+                importers.remove(self.MOBILITY_DATA)
+
             import_count = 0
             for imp in self.importer_types:
                 if imp not in importers:


### PR DESCRIPTION
# Implements the mobility_data argument

## Description
The smbackend_turku/README.md informs user that all mobility datas(that are suited)  can be imported to the services list with the argument "mobility_data". For some reason there was no implementation for it, so finally here it is implemented.


-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed 
 1. smbackend_turku/management/commands/turku_services_import.py
     * Now imports all external sources(mobility data) if the mobility_data arg is passed to the management command.
  