### PR TITLE
Change Django version to >=4.0.7

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django>=4.0.6
+Django>=4.0.7
 djangorestframework
 djangorestframework-jsonp
 Markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ coverage==5.5
     # via pytest-cov
 deprecated==1.2.13
     # via redis
-django==4.0.6
+django==4.0.7
     # via
     #   -r requirements.in
     #   django-celery-beat


### PR DESCRIPTION
# Fix for [Django 3.2 before 3.2.15 and 4.0 before 4.0.7 vulnerable to Reflected File Download attack](https://github.com/City-of-Turku/smbackend/security/dependabot/14).



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Dependencys
 1. requirements.in   
 2. requirements.txt
     * Change Django version to >=4.0.7
   