### PR TITLE
Change django-celery-results version to >=2.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -35,7 +35,7 @@ shapely
 celery
 # Currently only revision fa73034be892052893e4ef17926ef3a5d4a21ea2 of django-celery-beat supports django4
 git+https://github.com/celery/django-celery-beat.git#fa73034be892052893e4ef17926ef3a5d4a21ea2
-django-celery-results
+django-celery-results>=2.4.0
 redis
 libvoikko
 numpy>=1.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ django==4.0.6
     #   djangorestframework
 django-celery-beat @ git+https://github.com/celery/django-celery-beat.git
     # via -r requirements.in
-django-celery-results==2.2.0
+django-celery-results==2.4.0
     # via -r requirements.in
 django-cors-headers==3.9.0
     # via -r requirements.in


### PR DESCRIPTION
# Fix  for [django-celery-results vulnerable to Cleartext Storage of Sensitive Information](https://github.com/City-of-Turku/smbackend/security/dependabot/13).



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Dependencys
 1. requirements.in
 2. requirements.txt
    * Changed django-celery-results version to >=2.4.0
