### PR TITLE
Fix retrieving of units by address

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -999,7 +999,15 @@ class UnitViewSet(
             ).distinct()
 
         if "address" in filters:
-            queryset = queryset.filter(street_address__contains=filters["address"])
+            address_splitted = filters["address"].split(" ")
+            if len(address_splitted) == 1:
+                queryset = queryset.filter(
+                    street_address__startswith=address_splitted[0]
+                )
+            else:
+                queryset = queryset.filter(
+                    street_address__iregex=filters["address"] + r"($|\s|,|[a-zA-Z]).*"
+                )
 
         maintenance_organization = self.request.query_params.get(
             "maintenance_organization"


### PR DESCRIPTION
# Fix retrieving of units by address

## Description
Now i.e. if Yliopistonkatu 1 is given as arg it will not return Units with address Yliopistonkatu 11 but returns if the address is
Yliopistonkatu 1a or Yliopistonkatu 1b 8.krs.




-----------------------------------------------------------------------------------------------
### Breakdown:

#### API
 1. services/api.py
     * Filter address by startswith if only name otherwise with regexp to get the address prefix.
   
 