### PR TITLE
Feature/add geographical municipality to unit if none found

### DIFF
--- a/smbackend_turku/importers/utils.py
+++ b/smbackend_turku/importers/utils.py
@@ -8,7 +8,11 @@ import pytz
 import requests
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from munigeo.models import Municipality
+from munigeo.models import (
+    AdministrativeDivision,
+    AdministrativeDivisionGeometry,
+    Municipality,
+)
 
 from services.models import Service, ServiceNode, Unit
 
@@ -72,6 +76,20 @@ def get_ar_servicepoint_resource(resource_name=None):
 
     url = url_template.format(*template_vars)
     return get_resource(url)
+
+
+def get_municipality_name_by_point(point):
+    """
+    Returns the string name of the municipality in which the point
+    is located.
+    """
+    try:
+        # resolve in which division the point is.
+        division = AdministrativeDivisionGeometry.objects.get(boundary__contains=point)
+    except AdministrativeDivisionGeometry.DoesNotExist:
+        return None
+    # Get the division and return its name.
+    return AdministrativeDivision.objects.get(id=division.division_id).name
 
 
 def get_ar_servicepoint_accessibility_resource(resource_name=None):


### PR DESCRIPTION
# Add geographical municipality to unit if none found

## Description
Some of the source data does not contain data of the municipality, add the geographical municipality to these.
The municipality_id is used by the Search when filtering unit, if the municipality_id is null the search will not return these units.



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importer
 1. smbackend_turku/importers/units.py
     * Adds geographical municipality if none found in the source data.
   
 2. smbackend_turku/importers/utils.py
     * Added helper function that returns the name of the municipality with given point.
 