### PR TITLE
Fix bug with incorrect polygon dimensions

### DIFF
--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -137,12 +137,16 @@ class MobileUnitSerializer(serializers.ModelSerializer):
         elif isinstance(geometry, Polygon):
             if self.context["latlon"]:
                 # Return Polygon coordinates in (lat,lon) format
+                # The polygon needs to be a three dimensional array
+                # to be compatible with Leaflet polygon element.
+                polygon = []
                 coords = []
                 for coord in list(*geometry.coords):
                     # swap lon,lat -> lat lon
                     e = (coord[1], coord[0])
                     coords.append(e)
-                return coords
+                polygon.append(coords)
+                return polygon
             else:
                 return geometry.coords
         elif isinstance(geometry, MultiPolygon):


### PR DESCRIPTION
# Fix bug with incorrect polygon dimensions
## Description
Leaflet polygon element requires a three dimensional array for coordinates.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### API
 1. mobility_data/api/serializers/mobile_unit.py
     * Adds a dimension when serializing polygon with latlon set to true.
   
