### PR TITLE
Fix for empty task name in task results 

### DIFF
--- a/smbackend/settings.py
+++ b/smbackend/settings.py
@@ -298,6 +298,9 @@ CACHES = {
         "LOCATION": env("CACHE_LOCATION"),
     }
 }
+# Include extended information. i.e. name of the task etc. otherwise the name will be empty in 
+# version 2.4.0
+CELERY_RESULT_EXTENDED = True
 
 # Use in tests with override_settings CACHES = settings.TEST_CACHES
 TEST_CACHES = {


### PR DESCRIPTION
# Fix for empty task name in task results 

## Description
Since version 2.4.0 django-celery-results requires setting CELERY_RESULT_EXTENDED = True, to display the name
of the task in results. 

### Breakdown:

#### Settings
 1. smbackend/settings.py
     * Added CELERY_RESULT_EXTENDED = True
