### PR TITLE
Filter address by its municipality_id, not trough related street

### DIFF
--- a/services/search/api.py
+++ b/services/search/api.py
@@ -382,8 +382,9 @@ class SearchViewSet(GenericAPIView):
                 )
                 if len(municipalities) > 0:
                     addresses_qs = addresses_qs.filter(
-                        street__municipality_id__in=municipalities
+                        municipality_id__in=municipalities
                     )
+
             addresses_qs = addresses_qs[: model_limits["address"]]
             # Use naturalsort function that is migrated to munigeo to
             # sort the addresses.


### PR DESCRIPTION
# Filter address by municipality_id

## Description
As addresses now have a relation to municipalities use it to filter by municipality instead of using the related street and its municipality.


-----------------------------------------------------------------------------------------------
### Breakdown:

#### API
 1. services/search/api.py
     * Changed to filter by related municipality_id. Removed filter by related street and its municipality_id.
   
