### PR TITLE
Feature/search backward compatible serializer

### DIFF
--- a/services/search/api.py
+++ b/services/search/api.py
@@ -133,14 +133,6 @@ class SearchSerializer(serializers.Serializer):
                 self, obj
             )
             representation["department"] = DepartmentSerializer(obj.department).data
-            if object_type == "address":
-                set_address_fields(obj, representation)
-
-            if object_type == "service":
-                set_service_unit_count(obj, representation)
-                representation["root_service_node"] = RootServiceNodeSerializer(
-                    obj.root_service_node
-                ).data
             if self.context["geometry"]:
                 if obj.geometry:
                     representation["geometry"] = munigeo_api.geom_to_json(
@@ -149,6 +141,13 @@ class SearchSerializer(serializers.Serializer):
                 else:
                     representation["geometry"] = None
 
+        if object_type == "address":
+            set_address_fields(obj, representation)
+        if object_type == "service":
+            set_service_unit_count(obj, representation)
+            representation["root_service_node"] = RootServiceNodeSerializer(
+                obj.root_service_node
+            ).data
         if object_type == "unit" or object_type == "address":
             if obj.location:
                 representation["location"] = munigeo_api.geom_to_json(

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -236,7 +236,6 @@ class SearchViewSet(GenericAPIView):
 
         if "include" in params:
             include_fields = params["include"].split(",")
-            # breakpoint()
         else:
             include_fields = []
         # Limit number of results in searchquery.

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -157,29 +157,26 @@ class SearchSerializer(serializers.Serializer):
 
         for include in self.context["include"]:
             try:
-                include_object_type, field = include.split(".")
+                include_object_type, include_field = include.split(".")
             except ValueError:
                 raise ParseError(
                     "'include' list elements must be in format: entity.field, e.g., unit.connections."
                 )
 
             if object_type == "unit" and include_object_type == "unit":
-                if "connections" in field:
+                if "connections" in include_field:
                     representation["connections"] = UnitConnectionSerializer(
                         obj.connections, many=True
                     ).data
-                elif "phone" in field:
-                    representation["phone"] = getattr(obj, "phone")
-                elif "email" in field:
-                    representation["email"] = getattr(obj, "email")
-                elif "www" in field:
-                    representation["www"] = getattr(obj, "www")
-                elif "call_charge_info" in field:
-                    representation["call_charge_info"] = getattr(
-                        obj, "call_charge_info"
-                    )
-                elif "picture_url" in field:
-                    representation["picture_url"] = getattr(obj, "picture_url")
+                else:
+                    if hasattr(obj, include_field):
+                        representation[include_field] = getattr(
+                            obj, include_field, None
+                        )
+                    else:
+                        raise ParseError(
+                            f"Entity {object_type} does not contain a {include_field} field."
+                        )
 
         return representation
 

--- a/services/search/specification.swagger.yaml
+++ b/services/search/specification.swagger.yaml
@@ -103,10 +103,10 @@ components:
         type: integer
         example: 5
         default: No limit
-    extended_serializer_param:
-      name: extended_serializer
+    geometry_param:
+      name: geometry
       in: query
-      description: If set to true extends the number of fields to be serialized for units.
+      description: If set to true serializes the geometry of Units.
       schema:
         type: boolean
         default: false
@@ -129,6 +129,13 @@ components:
         items:
           type: string
       example: turku
+    include_param:
+      name: include
+      in: query
+      type: array
+      items:
+        type: string
+      description: A comma-separated list of enity.field e.g., unit.connections,unit.www.
     service_param:
         name: service
         in: query
@@ -168,9 +175,10 @@ paths:
         - $ref: "#/components/parameters/use_trigram_param"
         - $ref: "#/components/parameters/trigram_threshold_param"
         - $ref: "#/components/parameters/order_units_by_num_services_param"
-        - $ref: "#/components/parameters/extended_serializer_param"
+        - $ref: "#/components/parameters/geometry_param"
         - $ref: "#/components/parameters/sql_query_limit_param"
         - $ref: "#/components/parameters/unit_limit_param"
+        - $ref: "#/components/parameters/include_param"
         - $ref: "#/components/parameters/service_limit_param"
         - $ref: "#/components/parameters/servicenode_limit_param"   
         - $ref: "#/components/parameters/address_limit_param"


### PR DESCRIPTION
# Search backward compatible serializer and parameters



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. services/search/api.py
     * Added include param which takes a list of entity.field elements separated by comma and serializes them. Added boolean geometry param, if true serialize geometry for units. Removed obsolete extended_serializer param.
   
 2. services/search/specification.swagger.yaml
     * Added info about include and geometry params, removed extender_serializer.
    
 