### PR TITLE
Bugfix/serialization fails with latlon set to true if geometry element contains multiple lists

### DIFF
--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -13,6 +13,7 @@ from services.models import Unit
 
 from ...models import GroupType, MobileUnit, MobileUnitGroup
 from . import ContentTypeSerializer
+from .utils import swap_coords
 
 
 class GeometrySerializer(serializers.Serializer):
@@ -128,7 +129,7 @@ class MobileUnitSerializer(serializers.ModelSerializer):
                 coords = []
                 for coord in geometry.coords:
                     # swap lon,lat -> lat lon
-                    e = (coord[1], coord[0])
+                    e = swap_coords(coord)
                     coords.append(e)
                 return coords
             else:
@@ -141,10 +142,15 @@ class MobileUnitSerializer(serializers.ModelSerializer):
                 # to be compatible with Leaflet polygon element.
                 polygon = []
                 coords = []
-                for coord in list(*geometry.coords):
-                    # swap lon,lat -> lat lon
-                    e = (coord[1], coord[0])
-                    coords.append(e)
+                # If geometry.coords contains multiple lists they must be handled separately.
+                if len(geometry.coords) > 1:
+                    for geometry_coords in geometry.coords:
+                        for coord in geometry_coords:
+                            # swap lon,lat -> lat lon
+                            coords.append(swap_coords(coord))
+                else:
+                    for coord in list(*geometry.coords):
+                        coords.append(swap_coords(coord))
                 polygon.append(coords)
                 return polygon
             else:
@@ -158,8 +164,7 @@ class MobileUnitSerializer(serializers.ModelSerializer):
                     polygon_coords = []
                     for p_c in list(*polygon):
                         # swap lon,lat -> lat lon
-                        e = (p_c[1], p_c[0])
-                        polygon_coords.append(e)
+                        polygon_coords.append(swap_coords(p_c))
                     coords.append(polygon_coords)
                 return coords
             else:
@@ -170,8 +175,7 @@ class MobileUnitSerializer(serializers.ModelSerializer):
                 for linestring in geometry.coords:
                     # swap lon,lat -> lat lon
                     for coord in linestring:
-                        e = (coord[1], coord[0])
-                        coords.append(e)
+                        coords.append(swap_coords(coord))
                 return coords
             else:
                 return geometry.coords

--- a/mobility_data/api/serializers/utils.py
+++ b/mobility_data/api/serializers/utils.py
@@ -1,0 +1,2 @@
+def swap_coords(coord):
+    return (coord[1], coord[0])


### PR DESCRIPTION
# Fixes bug if polygon contains multiple lists when swapping coordinates

-----------------------------------------------------------------------------------------------
### Breakdown:

#### API
 1. mobility_data/api/serializers/mobile_unit.py 
     * Handle coord swap if polygon geometry contains multiple lists and use function for swapping coords.
 2. mobility_data/api/serializers/utils.py
     * Added function for swapping coords.
    
