### PR TITLE
Bugfix/get turku boundary returns raisio

### DIFF
--- a/street_maintenance/management/commands/constants.py
+++ b/street_maintenance/management/commands/constants.py
@@ -48,7 +48,7 @@ EVENT_MAPPINGS = {
 }
 # The number of works(point data with timestamp and event) to be fetched for every unit.
 INFRAROAD_DEFAULT_WORKS_HISTORY_SIZE = 10000
-# Length of Autori history size in days
+# Length of Autori history size in days, max value is 31.
 AUTORI_DEFAULT_WORKS_HISTORY_SIZE = 10
 AUTORI_MAX_WORKS_HISTORY_SIZE = 31
 AUTORI_DATE_TIME_FORMAT = "%Y-%m-%d %H:%M:%S%z"

--- a/street_maintenance/management/commands/utils.py
+++ b/street_maintenance/management/commands/utils.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("street_maintenance")
 
 
 def get_turku_boundary():
-    division_turku = AdministrativeDivision.objects.get(name="Raisio")
+    division_turku = AdministrativeDivision.objects.get(name="Turku")
     turku_boundary = AdministrativeDivisionGeometry.objects.get(
         division=division_turku
     ).boundary


### PR DESCRIPTION
# Bug fix, get_turku_boundary returns now the Turku boundary instead of Raisio.

## Description
Raisio was set for testing purposes, as Autori testing data only contains works that are located in Raisio.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. street_maintenance/management/commands/constants.py
    * Added comment about the max value for AUTORI_DEFAULT_WORKS_HISTORY_SIZE.
2. street_maintenance/management/commands/utils.py
    * Changed 'Raisio' to 'Turku'