### PR TITLE
Feature/division importer filter by turku boundarys add parish divisions update munigeo

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ django-modeltranslation
 flake8
 requests
 requests_cache
-git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.73#egg=django-munigeo
+git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.76#egg=django-munigeo
 pytz
 django-cors-headers
 django-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ django-mptt==0.13.4
     # via
     #   -r requirements.in
     #   django-munigeo
-django-munigeo @ git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.73
+django-munigeo @ git+https://github.com/City-of-Helsinki/django-munigeo@v0.2.76
     # via -r requirements.in
 django-polymorphic==3.1.0
     # via -r requirements.in

--- a/smbackend_turku/importers/data/divisions_config.yml
+++ b/smbackend_turku/importers/data/divisions_config.yml
@@ -97,4 +97,15 @@ divisions:
         sv: Oppilasalueen_kuvaus
       origin_id: Oppilasalueen_kuvaus
       ocd_id: Oppilasalueen_kuvaus
+
+  - type: parish
+    name: "Seurakunta"  
+    ocd_id: seurakunta
+    wfs_layer: 'GIS:Seurakunnat'
+    fields:
+      name:
+        fi: Numero
+      origin_id: Numero
+      ocd_id: Numero
+      
       

--- a/smbackend_turku/importers/utils.py
+++ b/smbackend_turku/importers/utils.py
@@ -239,6 +239,18 @@ def get_municipality(name):
         return None
 
 
+def get_turku_boundary():
+    division_turku = AdministrativeDivision.objects.filter(name="Turku").first()
+    if division_turku:
+        turku_boundary = AdministrativeDivisionGeometry.objects.get(
+            division=division_turku
+        ).boundary
+        turku_boundary.transform(settings.DEFAULT_SRID)
+        return turku_boundary
+    else:
+        return None
+
+
 def create_service_node(service_node_id, name, parent_name, service_node_names):
     """
     Creates service_node with given name and id if it does not exist.


### PR DESCRIPTION
# Import only division located in Turku, add parish divisions, update munigeo version(support for origin_id with max length 64)

-----------------------------------------------------------------------------------------------
### Breakdown:

####  Requirements
 1. requirements.in
 2. requirements.txt
     * Change django-munigeo version to 0.2.76.
#### Division importer
1. smbackend_turku/importers/data/divisions_config.yml
    * Add parish divisions.
2. smbackend_turku/importers/divisions.py
    * Include only division located in Turku.
3. smbackend_turku/importers/utils.py
    * Added function that return the Turku boundary.