### PR TITLE
Change ocd_id of postcode_area to lowercase

### DIFF
--- a/smbackend_turku/importers/data/divisions_config.yml
+++ b/smbackend_turku/importers/data/divisions_config.yml
@@ -5,7 +5,6 @@ paths:
     division: divisions
 
 divisions:
-
   - type: major_district
     name: Suurpiiri
     ocd_id: suurpiiri
@@ -51,7 +50,7 @@ divisions:
 
   - type: postcode_area
     name: Postinumeroalue
-    ocd_id: Postinumeroalue
+    ocd_id: postinumeroalue
     wfs_layer: 'GIS:Postinumeroalueet'
     check_turku_boundary: False
     fields:


### PR DESCRIPTION
# Fix bug, postalcode area not returning units

## Descripition
Reason for this was that the ocd_id name in the config started with a uppercase letter. ocd_id:s are in lowercase and
the ocd_id given as argument in the query is converted to lowercase.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Config
 1. smbackend_turku/importers/data/divisions_config.yml
     * Changed Postinumeroalue to postinumeroalue.
   
