### PR TITLE
Bugfix, get_municipality_name_by_point returns multiple AdministrativeDivisions

### DIFF
--- a/smbackend_turku/importers/utils.py
+++ b/smbackend_turku/importers/utils.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from munigeo.models import (
     AdministrativeDivision,
     AdministrativeDivisionGeometry,
+    AdministrativeDivisionType,
     Municipality,
 )
 
@@ -84,8 +85,14 @@ def get_municipality_name_by_point(point):
     is located.
     """
     try:
+        muni_type = AdministrativeDivisionType.objects.get(type="muni")
+    except AdministrativeDivisionType.DoesNotExist:
+        return None
+    try:
         # resolve in which division the point is.
-        division = AdministrativeDivisionGeometry.objects.get(boundary__contains=point)
+        division = AdministrativeDivisionGeometry.objects.get(
+            division__type=muni_type, boundary__contains=point
+        )
     except AdministrativeDivisionGeometry.DoesNotExist:
         return None
     # Get the division and return its name.


### PR DESCRIPTION
# Bugfix, get_municipality_name_by_point returns multiple AdministrativeDivisions


-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed
 1. smbackend_turku/importers/utils.py
     * Retrieve the municipality type and add it to the query which retrieves the AdministrativeGeometry. 