### PR TITLE
Feature/import disabled parking signs

### DIFF
--- a/mobility_data/README.md
+++ b/mobility_data/README.md
@@ -145,6 +145,14 @@ To import data type:
 ./manage.py import_wfs FitnessTrail
 ```
 
+### Crosswalk signs
+```
+./manage.py import_wfs CrossWalkSign
+```
+### Disabled parking signs
+```
+./manage.py import_wfs DisabledParkingSign
+```
 ## Deletion
 To delete mobile units for a content type.
 ```

--- a/mobility_data/importers/data/wfs_importer_config.yml
+++ b/mobility_data/importers/data/wfs_importer_config.yml
@@ -1,11 +1,18 @@
 features:
-  - content_type_name: CrossWalk
-    content_type_description: Crosswalks in the city of Turku.
+  - content_type_name: CrossWalkSign
+    content_type_description: Crosswalk signs in the city of Turku.
     wfs_layer: GIS:Liikennemerkit
     include:
-      Varustelaji: Suojatie
+      Varustelaji: 511 Suojatie
     max_features: 50000
-    
+
+  - content_type_name: DisabledParkingSign
+    content_type_description: Disabled parking signs in the city of Turku.
+    wfs_layer: GIS:Liikennemerkit
+    include:
+      Varustelaji: 836 Invalidin ajoneuvo
+    max_features: 50000
+
   - content_type_name: PaddlingTrail
     content_type_description: Paddling trails in Southwest Finland    
    # if not defined use the Turku WFS url set in environment

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -84,10 +84,15 @@ def delete_mobility_data(args=None, name="delete_mobility_data"):
 
 
 @shared_task
-def import_outdoor_trails(args=None, name="import_outdoor_trails"):
+def import_outdoor_trails(name="import_outdoor_trails"):
     management.call_command(
         "import_wfs", ["PaddlingTrail", "HikingTrail", "NatureTrail", "FitnessTrail"]
     )
+
+
+@shared_task
+def import_traffic_signs(name="import_traffic_signs"):
+    management.call_command("import_wfs", ["CrossWalkSign", "DisabledParkingSign"])
 
 
 @shared_task


### PR DESCRIPTION
# Import disabled parking signs


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed 
1. mobility_data/README.md
    * Add info about importing crosswalk and disabled parking signs.
2.  mobility_data/importers/data/wfs_importer_config.yml
     *  Add configuration for DisabledParkingSign, rename CrossWalk to CrossWalksign.
 3. mobility_data/tasks.py
     * Add task to import traffic signs.

