### PR TITLE
Feature/filter extra field with int or float

### DIFF
--- a/mobility_data/tests/conftest.py
+++ b/mobility_data/tests/conftest.py
@@ -65,12 +65,13 @@ def group_type():
 @pytest.mark.django_db
 @pytest.fixture
 def mobile_unit(content_type):
+    extra = {"test_int": 4242, "test_float": 42.42, "test_string": "4242"}
     mobile_unit = MobileUnit.objects.create(
         name="Test mobileunit",
         description="Test description",
         content_type=content_type,
         geometry=Point(42.42, 21.21, srid=settings.DEFAULT_SRID),
-        extra={"test": "4242"},
+        extra=extra,
     )
     return mobile_unit
 

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -33,8 +33,36 @@ def test_mobile_unit(api_client, mobile_unit, content_type):
     assert results["name"] == "Test mobileunit"
     assert results["description"] == "Test description"
     assert results["content_type"]["id"] == str(content_type.id)
-    assert results["extra"]["test"] == "4242"
+    assert results["extra"]["test_string"] == "4242"
+    assert results["extra"]["test_int"] == 4242
+    assert results["extra"]["test_float"] == 42.42
     assert results["geometry"] == Point(42.42, 21.21, srid=settings.DEFAULT_SRID)
+    url = (
+        reverse("mobility_data:mobile_units-list")
+        + "?type_name=Test?extra__test_string=4242"
+    )
+    response = api_client.get(url)
+    assert response.status_code == 200
+    results = response.json()["results"][0]
+    assert results["name"] == "Test mobileunit"
+    # Test int value in extra field
+    url = (
+        reverse("mobility_data:mobile_units-list")
+        + "?type_name=Test?extra__test_int=4242"
+    )
+    response = api_client.get(url)
+    assert response.status_code == 200
+    results = response.json()["results"][0]
+    assert results["name"] == "Test mobileunit"
+    # Test float value in extra field
+    url = (
+        reverse("mobility_data:mobile_units-list")
+        + "?type_name=Test?extra__test_float=42.42"
+    )
+    response = api_client.get(url)
+    assert response.status_code == 200
+    results = response.json()["results"][0]
+    assert results["name"] == "Test mobileunit"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# Filter extra field with int or float value as argument


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. mobility_data/api/views.py
    * Typecast 'extra__' argument to the type of jsonfields value.
2. mobility_data/tests/conftest.py
    * Add extra field with string, int and float value.
3. mobility_data/tests/test_api.py
    * Test extra filtering with string, int and float values.