### PR TITLE
Feature/street maintenance history improvements

### DIFF
--- a/street_maintenance/api/serializers.py
+++ b/street_maintenance/api/serializers.py
@@ -22,11 +22,16 @@ class MaintenanceUnitSerializer(serializers.ModelSerializer):
 
 
 class MaintenanceWorkSerializer(serializers.ModelSerializer):
+    provider = serializers.PrimaryKeyRelatedField(
+        many=False, source="maintenance_unit.provider", read_only=True
+    )
+
     class Meta:
         model = MaintenanceWork
         fields = [
             "id",
             "maintenance_unit",
+            "provider",
             "geometry",
             "timestamp",
             "events",

--- a/street_maintenance/api/views.py
+++ b/street_maintenance/api/views.py
@@ -14,8 +14,8 @@ from street_maintenance.api.serializers import (
 )
 from street_maintenance.models import DEFAULT_SRID, MaintenanceUnit, MaintenanceWork
 
-# Default is 30minutes 30*60s
-DEFAULT_MAX_WORK_LENGTH = 1800
+# Default is 3minutes 3*60s
+DEFAULT_MAX_WORK_LENGTH = 180
 
 
 class ActiveEventsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -107,9 +107,9 @@ class MaintenanceWorkViewSet(viewsets.ReadOnlyModelViewSet):
                         else:
                             geometries.append(elem.geometry)
                         points = []
-
                 points.append(elem.geometry)
                 prev_timestamp = elem.timestamp
+
             if len(points) > 1:
                 geometries.append(LineString(points, srid=DEFAULT_SRID))
             else:

--- a/street_maintenance/management/commands/constants.py
+++ b/street_maintenance/management/commands/constants.py
@@ -19,43 +19,59 @@ KUNTEC_WORKS_URL = (
     "https://mapon.com/api/v1/route/list.json?key={key}&from={start}"
     "&till={end}&include=polyline&unit_id={unit_id}"
 )
-# Events are categorized into flowwoing main groups:
+# Events are categorized into main groups:
 AURAUS = "auraus"
 LIUKKAUDENTORJUNTA = "liukkaudentorjunta"
 PUHTAANAPITO = "puhtaanapito"
 HIEKANPOISTO = "hiekanpoisto"
 # MUUT is currenlty only for testing purposes, TODO, remove from production
 MUUT = "muut"
+
 # As data providers have different names for their events, they are mapped
 # with this dict, so that every event that does the same has the same name.
+# The value is a list, as there can be events that belong to multiple main groups.
+# e.g., event "Auraus ja hiekanpoisto".
 EVENT_MAPPINGS = {
-    "auraus": AURAUS,
-    "auraus ja sohjonpoisto": AURAUS,
-    "lumen poisajo": AURAUS,
-    "lumensiirto": AURAUS,
-    "suolas": LIUKKAUDENTORJUNTA,
-    "suolaus (sirotinlaite)": LIUKKAUDENTORJUNTA,
-    "liuossuolaus": LIUKKAUDENTORJUNTA,
-    "hiekoitus": LIUKKAUDENTORJUNTA,
-    "hiekotus": LIUKKAUDENTORJUNTA,
-    "hiekoitus (sirotinlaite)": LIUKKAUDENTORJUNTA,
-    "linjahiekoitus": LIUKKAUDENTORJUNTA,
-    "pistehiekoitus": LIUKKAUDENTORJUNTA,
-    "paannejään poisto": LIUKKAUDENTORJUNTA,
-    "puhtaanapito": PUHTAANAPITO,
-    "harjaus": PUHTAANAPITO,
-    "pesu": PUHTAANAPITO,
-    "harjaus ja sohjonpoisto": PUHTAANAPITO,
-    "pölynsidonta": PUHTAANAPITO,
-    "hiekanpoisto": HIEKANPOISTO,
-    "muut työt": MUUT,
-    "lisätyö": MUUT,
-    "viherhoito": MUUT,
-    "kaivot": MUUT,
-    "metsätyöt": MUUT,
-    "rikkakasvien torjunta": MUUT,
-    "paikkaus": MUUT,
+    "Laiturin ja asema-alueen auraus": [AURAUS],
+    "au": [AURAUS],
+    "auraus": [AURAUS],
+    "auraus ja sohjonpoisto": [AURAUS],
+    "lumen poisajo": [AURAUS],
+    "lumensiirto": [AURAUS],
+    "suolas": [LIUKKAUDENTORJUNTA],
+    "suolaus (sirotinlaite)": [LIUKKAUDENTORJUNTA],
+    "liuossuolaus": [LIUKKAUDENTORJUNTA],
+    # Hiekoitus
+    "hi": [LIUKKAUDENTORJUNTA],
+    "su": [LIUKKAUDENTORJUNTA],
+    "hiekoitus": [LIUKKAUDENTORJUNTA],
+    "hiekotus": [LIUKKAUDENTORJUNTA],
+    "hiekoitus (sirotinlaite)": [LIUKKAUDENTORJUNTA],
+    "linjahiekoitus": [LIUKKAUDENTORJUNTA],
+    "pistehiekoitus": [LIUKKAUDENTORJUNTA],
+    "paannejään poisto": [LIUKKAUDENTORJUNTA],
+    # Kadunpesu
+    "pe": [PUHTAANAPITO],
+    # Harjaus
+    "hj": [PUHTAANAPITO],
+    # Hiekanpoisto
+    "hn": [PUHTAANAPITO],
+    "puhtaanapito": [PUHTAANAPITO],
+    "harjaus": [PUHTAANAPITO],
+    "pesu": [PUHTAANAPITO],
+    "harjaus ja sohjonpoisto": [PUHTAANAPITO],
+    "pölynsidonta": [PUHTAANAPITO],
+    "hiekanpoisto": [HIEKANPOISTO],
+    "muut työt": [MUUT],
+    "muu työ": [MUUT],
+    "lisätyö": [MUUT],
+    "viherhoito": [MUUT],
+    "kaivot": [MUUT],
+    "metsätyöt": [MUUT],
+    "rikkakasvien torjunta": [MUUT],
+    "paikkaus": [MUUT],
 }
+
 # The number of works(point data with timestamp and event) to be fetched for every unit.
 INFRAROAD_DEFAULT_WORKS_HISTORY_SIZE = 10000
 # Length of Autori history size in days, max value is 31.

--- a/street_maintenance/management/commands/import_autori_street_maintenance_history.py
+++ b/street_maintenance/management/commands/import_autori_street_maintenance_history.py
@@ -63,7 +63,8 @@ class Command(BaseCommand):
             for operation in operations:
                 event_name = event_name_mappings[operation].lower()
                 if event_name in EVENT_MAPPINGS:
-                    events.append(EVENT_MAPPINGS[event_name])
+                    for e in EVENT_MAPPINGS[event_name]:
+                        events.append(e)
                 else:
                     logger.warning(
                         f"Found unmapped event: {event_name_mappings[operation]}"

--- a/street_maintenance/management/commands/import_infraroad_street_maintenance_history.py
+++ b/street_maintenance/management/commands/import_infraroad_street_maintenance_history.py
@@ -59,9 +59,10 @@ class Command(BaseCommand):
 
                 events = []
                 for event in work["events"]:
-                    event_lower = event.lower()
-                    if event_lower in EVENT_MAPPINGS:
-                        events.append(EVENT_MAPPINGS[event_lower])
+                    event_name = event.lower()
+                    if event_name in EVENT_MAPPINGS:
+                        for e in EVENT_MAPPINGS[event_name]:
+                            events.append(e)
                     else:
                         logger.warning(f"Found unmapped event: {event}")
                 # If no events found discard the work

--- a/street_maintenance/management/commands/import_kuntec_street_maintenance_history.py
+++ b/street_maintenance/management/commands/import_kuntec_street_maintenance_history.py
@@ -55,7 +55,8 @@ class Command(BaseCommand):
                             for name in unit.names:
                                 event_name = name.lower()
                                 if event_name in EVENT_MAPPINGS:
-                                    events.append(EVENT_MAPPINGS[event_name])
+                                    for e in EVENT_MAPPINGS[event_name]:
+                                        events.append(e)
                                 else:
                                     logger.warning(
                                         f"Found unmapped event: {event_name}"
@@ -64,10 +65,10 @@ class Command(BaseCommand):
                         if len(events) > 0 and "polyline" in route:
                             coords = polyline.decode(route["polyline"], geojson=True)
                             geometry = LineString(coords, srid=DEFAULT_SRID)
-                            # Note, currently not in use as some geometrys might
-                            # start outside the boundarys of Turku.
-                            # if not TURKU_BOUNDARY.covers(geometry):
-                            #     continue
+                            # Note, some works(geometries) might start outside the boundarys
+                            # of Turku and are therefore discarded.
+                            if not TURKU_BOUNDARY.covers(geometry):
+                                continue
                             timestamp = route["start"]["time"]
                             works.append(
                                 MaintenanceWork(


### PR DESCRIPTION
# Street maintenance history improvements

## Description
Support for multiple events, added more events to mappings.


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importers
1. street_maintenance/management/commands/constants.py
    * Changed values to list in EVENT_MAPPINGS added new event mappings.
2. street_maintenance/management/commands/import_infraroad_street_maintenance_history.py
3. street_maintenance/management/commands/import_infraroad_street_maintenance_history.py
    * Adds multiple events if mapping containts multiple events.
4. street_maintenance/management/commands/import_kuntec_street_maintenance_history.py
    * Adds multiple events if mapping containts multiple events and filter geometries by the boundarys of Turku.
#### API
 1. street_maintenance/api/serializers.py
     * Added provider to works serializer. 
2. street_maintenance/api/views.py
    * Changed DEFAULT_MAX_WORK_LENGTH to 3min. This should remove generation of erroneous geometries(lines).