### PR TITLE
Feature/street maintenance history fix faulty linestrings

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     # Ubuntu latest is Ubuntu 20.04 as of 2022/6
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       # Database for tests

--- a/street_maintenance/api/views.py
+++ b/street_maintenance/api/views.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytz
 from django.contrib.gis.geos import LineString
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
@@ -13,6 +14,8 @@ from street_maintenance.api.serializers import (
     MaintenanceWorkSerializer,
 )
 from street_maintenance.models import DEFAULT_SRID, MaintenanceUnit, MaintenanceWork
+
+UTC_TIMEZONE = pytz.timezone("UTC")
 
 # Default is 3minutes 3*60s
 DEFAULT_MAX_WORK_LENGTH = 180
@@ -37,11 +40,14 @@ class MaintenanceWorkViewSet(viewsets.ReadOnlyModelViewSet):
         if "start_date_time" in filters:
             start_date_time = filters["start_date_time"]
             try:
-                datetime.strptime(start_date_time, "%Y-%m-%d %H:%M:%S")
+                start_date_time = datetime.strptime(
+                    start_date_time, "%Y-%m-%d %H:%M:%S"
+                )
             except ValueError:
                 raise ParseError(
-                    "'start_date_time' must be in format YYYY-MM-DD HH:MM elem.g.,'2022-09-18 10:00'"
+                    "'start_date_time' must be in format YYYY-MM-DD HH:MM:SS elem.g.,'2022-09-18 10:00:00'"
                 )
+            start_date_time = start_date_time.replace(tzinfo=UTC_TIMEZONE)
             queryset = queryset.filter(timestamp__gte=start_date_time)
         return queryset
 
@@ -97,10 +103,11 @@ class MaintenanceWorkViewSet(viewsets.ReadOnlyModelViewSet):
             qs = queryset.filter(maintenance_unit_id=unit_id).order_by("timestamp")
             prev_timestamp = None
             for elem in qs:
+
                 if prev_timestamp:
                     delta_time = elem.timestamp - prev_timestamp
                     # If delta_time is bigger than the max_work_length, then we can assume
-                    # that the work should not be in the same linestring/point.
+                    # that the work should not be in the same linestring/point .
                     if delta_time.seconds > max_work_length:
                         if len(points) > 1:
                             geometries.append(LineString(points, srid=DEFAULT_SRID))
@@ -125,7 +132,6 @@ class MaintenanceWorkViewSet(viewsets.ReadOnlyModelViewSet):
                     elem["name"] = "LineString"
                 else:
                     elem["name"] = "Point"
-
                 elem["coordinates"] = geometry.coords
                 data.append(elem)
         else:

--- a/street_maintenance/management/commands/constants.py
+++ b/street_maintenance/management/commands/constants.py
@@ -24,8 +24,8 @@ AURAUS = "auraus"
 LIUKKAUDENTORJUNTA = "liukkaudentorjunta"
 PUHTAANAPITO = "puhtaanapito"
 HIEKANPOISTO = "hiekanpoisto"
-# MUUT is currenlty only for testing purposes, TODO, remove from production
-MUUT = "muut"
+# MUUT is set to None as the events are not currently displayed.
+MUUT = None
 
 # As data providers have different names for their events, they are mapped
 # with this dict, so that every event that does the same has the same name.
@@ -38,6 +38,8 @@ EVENT_MAPPINGS = {
     "auraus ja sohjonpoisto": [AURAUS],
     "lumen poisajo": [AURAUS],
     "lumensiirto": [AURAUS],
+    "etuaura": [AURAUS],
+    "alusterä": [AURAUS],
     "suolas": [LIUKKAUDENTORJUNTA],
     "suolaus (sirotinlaite)": [LIUKKAUDENTORJUNTA],
     "liuossuolaus": [LIUKKAUDENTORJUNTA],
@@ -70,6 +72,9 @@ EVENT_MAPPINGS = {
     "metsätyöt": [MUUT],
     "rikkakasvien torjunta": [MUUT],
     "paikkaus": [MUUT],
+    "lisälaite 1": [MUUT],
+    "lisälaite 2": [MUUT],
+    "lisälaite 3": [MUUT],
 }
 
 # The number of works(point data with timestamp and event) to be fetched for every unit.

--- a/street_maintenance/management/commands/import_infraroad_street_maintenance_history.py
+++ b/street_maintenance/management/commands/import_infraroad_street_maintenance_history.py
@@ -23,7 +23,7 @@ TURKU_BOUNDARY = get_turku_boundary()
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
-            "--infraroad-history-size",
+            "--history-size",
             type=int,
             nargs="+",
             default=False,
@@ -62,7 +62,9 @@ class Command(BaseCommand):
                     event_name = event.lower()
                     if event_name in EVENT_MAPPINGS:
                         for e in EVENT_MAPPINGS[event_name]:
-                            events.append(e)
+                            # If mapping value is None, the event is not used.
+                            if e:
+                                events.append(e)
                     else:
                         logger.warning(f"Found unmapped event: {event}")
                 # If no events found discard the work
@@ -82,8 +84,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         importer_start_time = datetime.now()
         MaintenanceUnit.objects.filter(provider=MaintenanceUnit.INFRAROAD).delete()
-        if options["infraroad_history_size"]:
-            history_size = options["infraroad_history_size"][0]
+        if options["history_size"]:
+            history_size = options["history_size"][0]
         else:
             history_size = INFRAROAD_DEFAULT_WORKS_HISTORY_SIZE
         self.create_infraroad_maintenance_works(history_size)

--- a/street_maintenance/management/commands/import_kuntec_street_maintenance_history.py
+++ b/street_maintenance/management/commands/import_kuntec_street_maintenance_history.py
@@ -56,7 +56,9 @@ class Command(BaseCommand):
                                 event_name = name.lower()
                                 if event_name in EVENT_MAPPINGS:
                                     for e in EVENT_MAPPINGS[event_name]:
-                                        events.append(e)
+                                        # If mapping value is None, the event is not used.
+                                        if e:
+                                            events.append(e)
                                 else:
                                     logger.warning(
                                         f"Found unmapped event: {event_name}"
@@ -64,7 +66,11 @@ class Command(BaseCommand):
                         # If route has mapped event(s) and contains a polyline add work.
                         if len(events) > 0 and "polyline" in route:
                             coords = polyline.decode(route["polyline"], geojson=True)
-                            geometry = LineString(coords, srid=DEFAULT_SRID)
+                            if len(coords) > 2:
+                                geometry = LineString(coords, srid=DEFAULT_SRID)
+                            else:
+                                # coords with length 2 or less are faulty.
+                                continue
                             # Note, some works(geometries) might start outside the boundarys
                             # of Turku and are therefore discarded.
                             if not TURKU_BOUNDARY.covers(geometry):


### PR DESCRIPTION
# Remove importing of faulty linestrings, discard None events add event mappings.


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. street_maintenance/api/views.py
     * Add timezone to start_date_time. 
2. street_maintenance/management/commands/constants.py
    * Set 'MUUT' to None, so that they are not added to the database. Added event mappings 'etuaura', 'alusterä' and some MUUT events.
3. street_maintenance/management/commands/import_autori_street_maintenance_history.py
    * Add work only if coordinates length is greater than 2.  Discard None events. 
4. street_maintenance/management/commands/import_infraroad_street_maintenance_history.py
    * Change name of history-size param. Discard None events.
5. street_maintenance/management/commands/import_kuntec_street_maintenance_history.py
    * Add work only if coordinates length is greater than 2.  Discard None events. 
