### PR TITLE
Fix failing test_gas_filling_stations_import

### DIFF
--- a/mobility_data/importers/gas_filling_station.py
+++ b/mobility_data/importers/gas_filling_station.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from functools import lru_cache
 
 from django import db
@@ -64,8 +63,8 @@ class GasFillingStation:
 
 
 # Calling the url 'https://tie.digitraffic.fi/api/v3/data/traffic-messages/area-geometries?id=11&lastUpdated=false'
-# multiple times in a short period of time causes error '429 Too Many Request'. Cache the result when running tests.
-@lru_cache(maxsize=1 if "pytest" in sys.modules else 0)
+# multiple times in a short period of time causes error '429 Too Many Requests'. Cache the result.
+@lru_cache(maxsize=1)
 def get_geometry_data():
     return fetch_json(GEOMETRY_URL)
 

--- a/mobility_data/importers/gas_filling_station.py
+++ b/mobility_data/importers/gas_filling_station.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+from functools import lru_cache
 
 from django import db
 from django.conf import settings
@@ -61,11 +63,18 @@ class GasFillingStation:
         self.lng_cng = attributes.get("LNG_CNG", "")
 
 
+# Calling the url 'https://tie.digitraffic.fi/api/v3/data/traffic-messages/area-geometries?id=11&lastUpdated=false'
+# multiple times in a short period of time causes error '429 Too Many Request'. Cache the result when running tests.
+@lru_cache(maxsize=1 if "pytest" in sys.modules else 0)
+def get_geometry_data():
+    return fetch_json(GEOMETRY_URL)
+
+
 def get_filtered_gas_filling_station_objects(json_data=None):
     """
     Returns a list of GasFillingStation objects that are filtered by location.
     """
-    geometry_data = fetch_json(GEOMETRY_URL)
+    geometry_data = get_geometry_data()
     # Polygon used the detect if point intersects. i.e. is in the boundries.
     polygon = Polygon(geometry_data["features"][0]["geometry"]["coordinates"][0])
     if not json_data:


### PR DESCRIPTION
# Fix failing test_gas_filling_stations_import

## Description
Test failed due to that fetching multiple times the geometry data caused error '429 Too many Requests'

-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed
 1. mobility_data/importers/gas_filling_station.py
     * Cache the geometry result to avoid error '429 Too many requests '.

