### PR TITLE
Feature/refactor wfs importer test execution

### DIFF
--- a/mobility_data/importers/data/wfs_importer_config.yml
+++ b/mobility_data/importers/data/wfs_importer_config.yml
@@ -253,7 +253,6 @@ features:
     srid: 3877
     # If not set, use default value 1000
     max_features: 100
-    test_data: payment_zones.gml
     # If geometry contains multiple polygons create one multipolygon from the polygons
     create_multipolygon: True
     extra_fields:
@@ -280,22 +279,18 @@ features:
   - content_type_name: ScooterParkingArea
     content_type_description: Scooter parking zones in the Turku region.
     wfs_layer: GIS:Sahkopotkulautaparkki
-    test_data: scooter_parkings.gml
   
   - content_type_name: ScooterSpeedLimitArea
     content_type_description: Scooter speed limit zones in the Turku region.
     wfs_layer: GIS:Sahkopotkulauta_nopeusrajoitus
-    test_data: scooter_speed_limits.gml
 
   - content_type_name: ScooterNoParkingArea
     content_type_description: Scooter no parking zones in the Turku region.
     wfs_layer: GIS:Sahkopotkulauta_pysakointikielto
-    test_data: scooter_no_parking_zones.gml
 
   - content_type_name: PublicToilet
     content_type_description: Public toilets in the Turku region.
     wfs_layer: GIS:Varusteet
-    test_data: accessories.gml
     max_features: 10000
     # Default is False, if True include only if geometry locates in Turku.
     locates_in_turku: True
@@ -338,7 +333,6 @@ features:
   - content_type_name: PublicTable
     content_type_description: Public tables in the Turku region.
     wfs_layer: GIS:Varusteet
-    test_data: accessories.gml
     max_features: 10000
     locates_in_turku: True
     include:
@@ -379,7 +373,6 @@ features:
   - content_type_name: PublicBench
     content_type_description: Benches in the Turku region.
     wfs_layer: GIS:Varusteet
-    test_data: accessories.gml
     max_features: 10000
     locates_in_turku: True
     include:
@@ -420,7 +413,6 @@ features:
   - content_type_name: PublicFurnitureGroup
     content_type_description: Furniture groups in the Turku region.
     wfs_layer: GIS:Varusteet
-    test_data: accessories.gml
     max_features: 10000
     locates_in_turku: True
     include:
@@ -471,7 +463,6 @@ features:
     wfs_layer: GIS:Nopeusrajoitusalueet
     # If geometry contains multiple polygons create one multipolygon from the polygons
     create_multipolygon: True
-    test_data: speed_limits.gml
     extra_fields:
       speed_limit:
         wfs_field: voimassa_a

--- a/mobility_data/tests/test_import_accessories.py
+++ b/mobility_data/tests/test_import_accessories.py
@@ -26,7 +26,7 @@ def test_import_accessories(
     import_command(
         "import_wfs",
         ["PublicToilet", "PublicTable", "PublicBench", "PublicFurnitureGroup"],
-        test_mode=True,
+        data_file=f"{settings.BASE_DIR}/mobility_data/tests/data/accessories.gml",
     )
 
     public_toilet_content_type = ContentType.objects.get(name="PublicToilet")

--- a/mobility_data/tests/test_import_payment_zones.py
+++ b/mobility_data/tests/test_import_payment_zones.py
@@ -18,7 +18,11 @@ from .utils import import_command
 
 @pytest.mark.django_db
 def test_import_payment_zones():
-    import_command("import_wfs", "PaymentZone", test_mode=True)
+    import_command(
+        "import_wfs",
+        "PaymentZone",
+        data_file=f"{settings.BASE_DIR}/mobility_data/tests/data/payment_zones.gml",
+    )
     assert ContentType.objects.all().count() == 1
     content_type = ContentType.objects.first()
     assert content_type.name == "PaymentZone"

--- a/mobility_data/tests/test_import_scooter_restrictions.py
+++ b/mobility_data/tests/test_import_scooter_restrictions.py
@@ -34,8 +34,8 @@ https://opaskartta.turku.fi/TeklaOGCWeb/WFS.ashx
 def test_import_scooter_restrictions():
     import_command(
         "import_wfs",
-        ["ScooterParkingArea", "ScooterSpeedLimitArea", "ScooterNoParkingArea"],
-        test_mode=True,
+        "ScooterParkingArea",
+        data_file=f"{settings.BASE_DIR}/mobility_data/tests/data/scooter_parkings.gml",
     )
     # Test scooter parking
     parking_content_type = ContentType.objects.get(name="ScooterParkingArea")
@@ -46,7 +46,11 @@ def test_import_scooter_restrictions():
     parking_unit.content_type == parking_content_type
     point = Point(239576.42, 6711050.26, srid=DEFAULT_SOURCE_DATA_SRID)
     parking_unit.geometry.equals_exact(point, tolerance=0.0001)
-
+    import_command(
+        "import_wfs",
+        "ScooterSpeedLimitArea",
+        data_file=f"{settings.BASE_DIR}/mobility_data/tests/data/scooter_speed_limits.gml",
+    )
     # Test scooter speed limits
     speed_limit_content_type = ContentType.objects.get(name="ScooterSpeedLimitArea")
     assert speed_limit_content_type
@@ -59,7 +63,11 @@ def test_import_scooter_restrictions():
     # Scooter speed limit unit locates in the market square(kauppator)
     assert speed_limit_unit.geometry.contains(market_square) is True
     assert speed_limit_unit.geometry.contains(turku_cathedral) is False
-
+    import_command(
+        "import_wfs",
+        "ScooterNoParkingArea",
+        data_file=f"{settings.BASE_DIR}/mobility_data/tests/data/scooter_no_parking_zones.gml",
+    )
     # Test scooter no parking zones
     no_parking_content_type = ContentType.objects.get(name="ScooterNoParkingArea")
     assert no_parking_content_type

--- a/mobility_data/tests/test_import_speed_limits.py
+++ b/mobility_data/tests/test_import_speed_limits.py
@@ -9,6 +9,7 @@ has been removed from the test input data, as it causes GDAL
 DataSource to fail when loading data.
 """
 import pytest
+from django.conf import settings
 
 from mobility_data.models import ContentType, MobileUnit
 
@@ -17,7 +18,11 @@ from .utils import import_command
 
 @pytest.mark.django_db
 def test_import_speed_limits():
-    import_command("import_wfs", "SpeedLimitZone", test_mode=True)
+    import_command(
+        "import_wfs",
+        "SpeedLimitZone",
+        data_file=f"{settings.BASE_DIR}/mobility_data/tests/data/speed_limits.gml",
+    )
 
     assert ContentType.objects.all().count() == 1
     content_type = ContentType.objects.first()


### PR DESCRIPTION
# Refactor WFS importer 

## Description
Add possibility to send the data as a file given as argument and a config file given as argument. And some minor refactoring.



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importer
1. mobility_data/importers/data/wfs_importer_config.yml
    * Remove test_data field as it is now obsolete and the fixture filename is passed when calling the importer from tests.
2. mobility_data/importers/wfs.py
    * Remove test_mode, add support for loading data from a file. Some refactoring.
3. mobility_data/management/commands/import_wfs.py
    * Add data_file and config_file parameters.
 #### Tests
1. mobility_data/tests/test_import_accessories.py
2. mobility_data/tests/test_import_payment_zones.py
3. mobility_data/tests/test_import_scooter_restrictions.py
4. mobility_data/tests/test_import_speed_limits.py
    * Pass fixture file path and name as argument when calling importer.