### PR TITLE
Feature/import route for disabled sign

### DIFF
--- a/mobility_data/importers/data/wfs_importer_config.yml
+++ b/mobility_data/importers/data/wfs_importer_config.yml
@@ -97,6 +97,13 @@ features:
       Varustelaji: 511 Suojatie
     max_features: 50000
 
+  - content_type_name: RouteForDisabledSign
+    content_type_description: Route for disabled signs in the city of Turku.
+    wfs_layer: GIS:Liikennemerkit
+    include:
+      Varustelaji: 683 Vammaisille tarkoitettu reitti
+    max_features: 50000
+    
   - content_type_name: DisabledParkingSign
     content_type_description: Disabled parking signs in the city of Turku.
     wfs_layer: GIS:Liikennemerkit

--- a/mobility_data/management/commands/import_wfs.py
+++ b/mobility_data/management/commands/import_wfs.py
@@ -23,6 +23,8 @@ def get_configured_cotent_type_names(config=None):
 
 class Command(BaseCommand):
     config = get_yaml_config(CONFIG_FILE)
+    # Read all the defined content types from the config
+    choices = get_configured_cotent_type_names(config)
 
     def add_arguments(self, parser):
 
@@ -36,10 +38,9 @@ class Command(BaseCommand):
             nargs="?",
             help="YAML config file for features.",
         )
-
-        # Read all the defined content types from the config
-        choices = get_configured_cotent_type_names(self.config)
-        parser.add_argument("content_type_names", nargs="*", help=", ".join(choices))
+        parser.add_argument(
+            "content_type_names", nargs="*", help=", ".join(self.choices)
+        )
 
     def handle(self, *args, **options):
         if options["config_file"]:
@@ -48,6 +49,14 @@ class Command(BaseCommand):
         data_file = None
         if options["data_file"]:
             data_file = options["data_file"]
+
+        # Check if ContentTypes given as arguments exists.
+        if options["content_type_names"]:
+            for content_type_name in options["content_type_names"]:
+                if content_type_name not in self.choices:
+                    logger.warning(
+                        f"ContentType {content_type_name} not found in config, discarding..."
+                    )
 
         for feature in self.config["features"]:
             if (

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -109,6 +109,7 @@ def import_traffic_signs(name="import_traffic_signs"):
             "RailwayLevelCrossingWithBoomsSign",
             "SingleTrackRailwayLevelCrossingSign",
             "TicketMachineSign",
+            "RouteForDisabledSign",
         ],
     )
 


### PR DESCRIPTION
# Import route for disabled sign



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. mobility_data/importers/data/wfs_importer_config.yml
     * Add configuration for RouteForDisableSign.
2. mobility_data/management/commands/import_wfs.py
    * Add check if ContentType argument exists.
3. mobility_data/management/commands/import_wfs.py
    * Add RouteForDisabledSign to import_traffic_sign task