### PR TITLE
Add CONFIG_FILE arg to get_yaml_config function call

### DIFF
--- a/mobility_data/management/commands/import_wfs.py
+++ b/mobility_data/management/commands/import_wfs.py
@@ -17,7 +17,7 @@ def get_yaml_config(file):
 
 def get_configured_cotent_type_names(config=None):
     if not config:
-        config = get_yaml_config()
+        config = get_yaml_config(CONFIG_FILE)
     return [f["content_type_name"] for f in config["features"]]
 
 


### PR DESCRIPTION
# Add CONFIG_FILE arg to get_yaml_config function call

## Description
This also fixes bug if no config file is provided when calling the importer.
-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed
1. mobility_data/management/commands/import_wfs.py
    * Added CONFIG_FILE arg to get_yaml_config function call.