### PR TITLE
Remove 'type_name' from GroupTypeBasicInfoSerializer

### DIFF
--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -28,7 +28,7 @@ class GeometrySerializer(serializers.Serializer):
 class GrouptTypeBasicInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = GroupType
-        fields = ["id", "name", "type_name"]
+        fields = ["id", "name"]
 
 
 class MobileUnitGroupBasicInfoSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
# Fix bug GroupTypeBasicInfoSerializer serializes non existing field
-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed
 1. mobility_data/api/serializers/mobile_unit.py 
     * Remove 'type_name'  as it has been removed from the model.
   
 