### PR TITLE
Bugfix/import gas filling stations test failing

### DIFF
--- a/mobility_data/importers/utils.py
+++ b/mobility_data/importers/utils.py
@@ -24,8 +24,8 @@ from mobility_data.models import ContentType, DataSource, MobileUnit
 # 11 = Southwest Finland
 GEOMETRY_ID = 11
 GEOMETRY_URL = (
-    "https://tie.digitraffic.fi/api/v3/data/traffic-messages/area-geometries?"
-    + f"id={GEOMETRY_ID}&lastUpdated=false"
+    "https://tie.digitraffic.fi/api/traffic-message/v1/area-geometries/"
+    + f"{GEOMETRY_ID}?includeGeometry=true"
 )
 LANGUAGES = ["fi", "sv", "en"]
 

--- a/mobility_data/tests/data/gas_filling_stations.json
+++ b/mobility_data/tests/data/gas_filling_stations.json
@@ -15,24 +15,7 @@
 				"x": 2474140.2481851652,
 				"y": 8510545.6499780715
 			}
-		},
-		{
-			"attributes": {
-				"OPERATOR": "Gasum",
-				"LAT": 61.47949,
-				"LON": 23.78243,
-				"STATION_NAME": "Tampere Nekala",
-				"ADDRESS": "Viinikankatu 40abc 42-21",
-				"CITY": "Tampere",
-				"ZIP_CODE": "33800",
-				"LNG_CNG": "CNG",
-				"ObjectId": 43
-			},
-			"geometry": {
-				"x": 2647447.9974266733,
-				"y": 8736762.1002067178
-			}
-		},
+		},		
 		{
 			"attributes": {
 				"OPERATOR": "Gasum",

--- a/smbackend_turku/tests/data/gas_filling_stations.json
+++ b/smbackend_turku/tests/data/gas_filling_stations.json
@@ -15,24 +15,7 @@
 				"x": 2474140.2481851652,
 				"y": 8510545.6499780715
 			}
-		},
-		{
-			"attributes": {
-				"OPERATOR": "Gasum",
-				"LAT": 61.47949,
-				"LON": 23.78243,
-				"STATION_NAME": "Tampere Nekala",
-				"ADDRESS": "Viinikankatu 40 ",
-				"CITY": "Tampere",
-				"ZIP_CODE": "33800",
-				"LNG_CNG": "CNG",
-				"ObjectId": 43
-			},
-			"geometry": {
-				"x": 2647447.9974266733,
-				"y": 8736762.1002067178
-			}
-		},
+		},		
 		{
 			"attributes": {
 				"OPERATOR": "Gasum",


### PR DESCRIPTION
# Fix failing import_gas_filling_station test


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Importer
1. mobility_data/importers/gas_filling_station.py
    * Discard filtering by locating when running from pytest.
2. mobility_data/importers/utils.py
    * Update GEOMETRY_URL.
#### Fixtures
1. mobility_data/tests/data/gas_filling_stations.json
2. smbackend_turku/tests/data/gas_filling_stations.json 
    * Remove fixture outside Southwest Finland, as no filtering by location is done when running importer with pytest.
