### PR TITLE
Feature/eco counter get year datas endpoint

### DIFF
--- a/eco_counter/api/views.py
+++ b/eco_counter/api/views.py
@@ -228,6 +228,25 @@ class YearDataViewSet(viewsets.ReadOnlyModelViewSet):
         serializer = YearDataSerializer(queryset, many=False)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @action(detail=False, methods=["get"])
+    def get_year_datas(self, request):
+        start_year_number = request.query_params.get("start_year_number", None)
+        end_year_number = request.query_params.get("end_year_number", None)
+        station_id = request.query_params.get("station_id", None)
+        if start_year_number is None or end_year_number is None or station_id is None:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+        try:
+            queryset = YearData.objects.filter(
+                station_id=station_id,
+                year__year_number__gte=start_year_number,
+                year__year_number__lte=end_year_number,
+            ).order_by("year__year_number")
+        except YearData.DoesNotExist:
+            return Response(NOT_FOUND_RESPONSE_MSG, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer = YearDataSerializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
 
 class DayViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Day.objects.all()

--- a/eco_counter/specification.swagger2.0.yaml
+++ b/eco_counter/specification.swagger2.0.yaml
@@ -243,6 +243,11 @@ paths:
   /stations/:
     get:
       summary: "Returns a list of stations."
+      parameters:
+      - in: query
+        description: "The type of the counter EC(Eco Counter), TC(Traffic Counter), LC(LAM Counter)"
+        name: counter_type
+        type: string
       responses:
         200:
           description: "List of stations."
@@ -286,6 +291,10 @@ paths:
     get:
       summary: "Returns a hour_data by id."
       parameters:
+      - in: query
+        description: "YYYY-MM-DD"
+        name: date
+        type: string
       - name: "id"
         in: path
         type: integer

--- a/eco_counter/specification.swagger2.0.yaml
+++ b/eco_counter/specification.swagger2.0.yaml
@@ -243,11 +243,6 @@ paths:
   /stations/:
     get:
       summary: "Returns a list of stations."
-      parameters:
-      - in: query
-        description: "The type of the counter EC(Eco Counter), TC(Traffic Counter), LC(LAM Counter)"
-        name: counter_type
-        type: string
       responses:
         200:
           description: "List of stations."
@@ -291,10 +286,6 @@ paths:
     get:
       summary: "Returns a hour_data by id."
       parameters:
-      - in: query
-        description: "YYYY-MM-DD"
-        name: date
-        type: string
       - name: "id"
         in: path
         type: integer
@@ -619,5 +610,32 @@ paths:
             $ref: "#/definitions/year_data"
         400:
           description: "Invalid year number or station_id." 
-        
+  /year_data/get_year_datas:
+    get:
+      summary: "Returns year_datas for  span of year numbers and station_id"
+      parameters:     
+      - in: query
+        name: start_year_number
+        type: integer
+        required: true
+      - in: query
+        name: end_year_number
+        type: integer
+        required: true
+      - in: query
+        name: station_id
+        type: integer
+        required: true
+      responses:
+        200:
+          description: "List of year_datas for the given span."
+          schema:
+            type: object
+            properties:
+              results:
+                type: array
+                items:
+                  $ref: "#/definitions/year_data"
+        400:
+          description: "Invalid start_year_number, end_year_number or station_id."        
   

--- a/eco_counter/tests/conftest.py
+++ b/eco_counter/tests/conftest.py
@@ -19,6 +19,7 @@ from eco_counter.models import (
 )
 
 TEST_TIMESTAMP = dateutil.parser.parse("2020-01-01 00:00:00")
+
 TEST_STATION_NAME = "Auransilta"
 
 
@@ -212,6 +213,7 @@ def year_datas(station, years):
         year_data = YearData.objects.create(station=station, year=years[i])
         year_data.value_ak = 42 + i
         year_data.value_ap = 43 + i
+        year_data.value_at = year_data.value_ak + year_data.value_ap
         year_data.save()
         year_datas.append(year_data)
     return year_datas

--- a/eco_counter/tests/test_api.py
+++ b/eco_counter/tests/test_api.py
@@ -146,6 +146,35 @@ def test__get_month_data(api_client, month_datas, station_id, test_timestamp):
 
 
 @pytest.mark.django_db
+def test__get_year_datas(api_client, year_datas, station_id, test_timestamp):
+    end_year_number = test_timestamp.replace(year=test_timestamp.year + 1).year
+    url = reverse(
+        "eco_counter:year_data-get-year-datas"
+    ) + "?station_id={}&start_year_number={}&end_year_number={}".format(
+        station_id, test_timestamp.year, end_year_number
+    )
+    response = api_client.get(url)
+    assert response.status_code == 200
+    json_data = response.json()
+    index = 0
+    assert json_data[index]["year_info"]["year_number"] == 2020
+    assert json_data[index]["value_ak"] == 42
+    assert json_data[index]["value_ap"] == 43
+    assert (
+        json_data[index]["value_at"]
+        == json_data[index]["value_ak"] + json_data[index]["value_ap"]
+    )
+    index = 1
+    assert json_data[index]["year_info"]["year_number"] == 2021
+    assert json_data[index]["value_ak"] == 43
+    assert json_data[index]["value_ap"] == 44
+    assert (
+        json_data[index]["value_at"]
+        == json_data[index]["value_ak"] + json_data[index]["value_ap"]
+    )
+
+
+@pytest.mark.django_db
 def test__get_month_datas(api_client, month_datas, station_id, test_timestamp):
     url = reverse(
         "eco_counter:month_data-get-month-datas"


### PR DESCRIPTION
# Eco-Counter, endpoint for retrieving year datas for a given span



-----------------------------------------------------------------------------------------------
### Breakdown:

#### API
1. eco_counter/api/views.py
    * Add endpoint for getting year data for a given span
#### Tests
1. eco_counter/tests/conftest.py
   * Add value_at to year datas fixture. 
2. eco_counter/tests/test_api.py
   * Add tests for get_year_datas endpoint.
#### Documentation
1. eco_counter/specification.swagger2.0.yaml
    * Add info about get_year_datas endpoint.

