### PR TITLE
Dependabot/pypa wheel vulnerable to regular expression denial of service #18

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -41,3 +41,4 @@ libvoikko
 numpy>=1.22
 pyshp
 polyline
+wheel>0.38.1

--- a/requirements.in
+++ b/requirements.in
@@ -41,4 +41,4 @@ libvoikko
 numpy>=1.22
 pyshp
 polyline
-wheel>0.38.1
+wheel>=0.38.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ billiard==3.6.4.0
     # via celery
 black==22.6.0
     # via -r requirements.in
+build==0.9.0
+    # via pip-tools
 cattrs==1.8.0
     # via requests-cache
 celery==5.2.3
@@ -126,6 +128,7 @@ numpy==1.23.0
     #   pandas
 packaging==21.0
     # via
+    #   build
     #   pytest
     #   redis
 pandas==1.4.3
@@ -137,10 +140,10 @@ parso==0.8.2
 pathspec==0.9.0
     # via black
 pep517==0.11.0
-    # via pip-tools
+    # via build
 pep8-naming==0.12.1
     # via -r requirements.in
-pip-tools==6.3.0
+pip-tools==6.12.1
     # via -r requirements.in
 platformdirs==2.4.0
     # via black
@@ -221,6 +224,7 @@ toml==0.10.2
 tomli==1.2.1
     # via
     #   black
+    #   build
     #   pep517
 tqdm==4.62.3
     # via -r requirements.in
@@ -239,8 +243,10 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
-wheel==0.37.0
-    # via pip-tools
+wheel==0.38.4
+    # via
+    #   -r requirements.in
+    #   pip-tools
 whitenoise==5.3.0
     # via -r requirements.in
 wrapt==1.13.3


### PR DESCRIPTION
# Fix for https://github.com/City-of-Turku/smbackend/security/dependabot/18

#### Requirements
 1. requirements.in
     * Set wheel version to >=0.38.
 2. requirements.txt
     * Change wheels and pip-tools versions
    

