### PR TITLE
Feature/search filter by rank and generate syllables only for compoundwords

### DIFF
--- a/services/search/constants.py
+++ b/services/search/constants.py
@@ -16,5 +16,4 @@ DEFAULT_MODEL_LIMIT_VALUE = None
 # The limit value for the search query that search the search_view. "NULL" = no limit
 DEFAULT_SEARCH_SQL_LIMIT_VALUE = "NULL"
 DEFAULT_TRIGRAM_THRESHOLD = 0.15
-# If word length is greater or equal then hyphenate word.
-LENGTH_OF_HYPHENATED_WORDS = 8
+DEFAULT_RANK_THRESHOLD = 0

--- a/services/search/specification.swagger.yaml
+++ b/services/search/specification.swagger.yaml
@@ -49,10 +49,16 @@ components:
         type: string
         example: unit,address
         default: unit
+    rank_threshold_param:
+      name: rank_threshold
+      in: query
+      desription: Include results with search rank greater than or equal to the value.
+      type: number 
+      default: 0
     trigram_threshold_param:
       name: trigram_threshold
       in: query
-      desription: The threshold value, if trigram similarity is greater-than or equal to this value return the result.
+      description: The threshold value, if trigram similarity is greater than or equal to this value return the result.
       type: number 
       default: 0.15
     sql_query_limit_param:

--- a/services/search/utils.py
+++ b/services/search/utils.py
@@ -5,7 +5,6 @@ from django.db.models import Case, When
 from services.models import ServiceNode, ServiceNodeUnitCount, Unit
 from services.search.constants import (
     DEFAULT_TRIGRAM_THRESHOLD,
-    LENGTH_OF_HYPHENATED_WORDS,
     SEARCHABLE_MODEL_TYPE_NAMES,
 )
 
@@ -13,17 +12,22 @@ voikko = libvoikko.Voikko("fi")
 voikko.setNoUglyHyphenation(True)
 
 
+def is_compound_word(word):
+    result = voikko.analyze(word)
+    if len(result) == 0:
+        return False
+    return True if result[0]["WORDBASES"].count("+") > 1 else False
+
+
 def hyphenate(word):
     """
-    Returns a list of syllables of the word if word length
-    is >= LENGTH_OF_HYPHENATE_WORDS
+    Returns a list of syllables of the word if it is a compound word.
     """
-    word_length = len(word)
-    if word_length >= LENGTH_OF_HYPHENATED_WORDS:
-        # By Setting the value to word_length, voikko returns
-        # the words that are in the compound word, if the word is
-        # not a compound word it returns the syllables as normal.
-        voikko.setMinHyphenatedWordLength(word_length)
+    word = word.strip()
+    if is_compound_word(word):
+        # By Setting the setMinHyphenatedWordLength to word_length,
+        # voikko returns the words that are in the compound word
+        voikko.setMinHyphenatedWordLength(len(word))
         syllables = voikko.hyphenate(word)
         return syllables.split("-")
     else:


### PR DESCRIPTION
# Filter by rank and generate syllables for only for compounwords.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changes
1. services/search/api.py
   * Filter by rank and add rank_threshold param
2. services/search/constants.py
    * Remove LENGTH_OF_HYPHENATED_WORDS constant
3. services/search/specification.swagger.yaml
    * Add info about rank_threshold_param
4. services/search/utils.py
   * Hyphenate only compound words
