### PR TITLE
Bugfix/eco counter weeks not deleted correctly if year starts with week 52

### DIFF
--- a/eco_counter/management/commands/import_counter_data.py
+++ b/eco_counter/management/commands/import_counter_data.py
@@ -287,7 +287,7 @@ class Command(BaseCommand):
                 years__year_number=current_year_number,
                 station__csv_data_source=csv_data_source,
             ).delete()
-
+        # Set the references to the current state.
         for station in stations:
             current_years[station] = Year.objects.get_or_create(
                 station=stations[station], year_number=current_year_number


### PR DESCRIPTION
# Handle year starting with week number >=52


-----------------------------------------------------------------------------------------------
### Breakdown:
#### File changed
 1. eco_counter/management/commands/import_counter_data.py
     * Handle year starting with week number >=52