### PR TITLE
Feature/outdoor gym devices importer

### DIFF
--- a/mobility_data/README.md
+++ b/mobility_data/README.md
@@ -153,6 +153,13 @@ To import data type:
 ```
 ./manage.py import_wfs DisabledParkingSign
 ```
+
+### Outdoor gym devices
+Imports the outdoor gym devices from services.unit model. i.e., sets refrences by id to the services.unit model. The data is serialized from the services.unit model.
+```
+./manage.py import_outdoor_gym_devices
+```
+
 ## Deletion
 To delete mobile units for a content type.
 ```

--- a/mobility_data/README.md
+++ b/mobility_data/README.md
@@ -155,7 +155,7 @@ To import data type:
 ```
 
 ### Outdoor gym devices
-Imports the outdoor gym devices from services.unit model. i.e., sets refrences by id to the services.unit model. The data is serialized from the services.unit model.
+Imports the outdoor gym devices from the services.unit model. i.e., sets references by id to the services.unit model. The data is then serialized from the services.unit model.
 ```
 ./manage.py import_outdoor_gym_devices
 ```

--- a/mobility_data/importers/outdoor_gym_devices.py
+++ b/mobility_data/importers/outdoor_gym_devices.py
@@ -1,0 +1,41 @@
+import logging
+
+from django import db
+
+from mobility_data.models import MobileUnit
+from services.models import Service, Unit
+
+from .utils import delete_mobile_units, get_or_create_content_type
+
+logger = logging.getLogger("mobility_data")
+SERVICE_NAME = "Outdoor Gym Devices"
+CONTENT_TYPE_NAME = "OutdoorGymDevice"
+
+db.transaction.atomic
+
+
+def create_content_type():
+    description = "Outdoor gym devices in Turku."
+    content_type, _ = get_or_create_content_type(CONTENT_TYPE_NAME, description)
+    return content_type
+
+
+db.transaction.atomic
+
+
+def save_outdoor_gym_devices():
+    """
+    Save only the ID of the Unit. The data will be serialized
+    from the Unit table using this ID.
+    """
+    delete_mobile_units(CONTENT_TYPE_NAME)
+    try:
+        service = Service.objects.get(name_en=SERVICE_NAME)
+    except Service.DoesNotExist:
+        return 0
+
+    content_type = create_content_type()
+    units_qs = Unit.objects.filter(services=service)
+    for unit in units_qs:
+        MobileUnit.objects.create(content_type=content_type, unit_id=unit.id)
+    return units_qs.count()

--- a/mobility_data/management/commands/import_mobility_data.py
+++ b/mobility_data/management/commands/import_mobility_data.py
@@ -22,6 +22,7 @@ importers = [
     "disabled_and_no_staff_parkings",
     "loading_and_unloading_places",
     "lounaistieto_shapefiles",
+    "outdoor_gym_devices",
 ]
 # Read the content type names to be imported
 wfs_content_type_names = get_configured_cotent_type_names()

--- a/mobility_data/management/commands/import_outdoor_gym_devices.py
+++ b/mobility_data/management/commands/import_outdoor_gym_devices.py
@@ -1,0 +1,12 @@
+import logging
+
+from mobility_data.importers.outdoor_gym_devices import save_outdoor_gym_devices
+
+from ._base_import_command import BaseImportCommand
+
+logger = logging.getLogger("mobility_data")
+
+
+class Command(BaseImportCommand):
+    def handle(self, *args, **options):
+        logger.info(f"Imported {save_outdoor_gym_devices()} outdoor gym devices")

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -59,6 +59,11 @@ def import_marinas(name="import_marinas"):
 
 
 @shared_task
+def import_outdoor_gym_devices(name="import_outdoor_gym_devices"):
+    management.call_command("import_outdoor_gym_devices")
+
+
+@shared_task
 def import_disabled_and_no_staff_parkings(name="import_disabled_and_no_staff_parkings"):
     management.call_command("import_disabled_and_no_staff_parkings")
 


### PR DESCRIPTION
# Importer for outdoor gym devices

## Description
Imports the outdoor gym devices from services.unit model. i.e., sets refrences by id to the services.unit model. The data is then serialized from the services.unit model.
-----------------------------------------------------------------------------------------------
### Breakdown:
#### Importers
1. mobility_data/importers/outdoor_gym_devices.py
    * Add importer for outdoor gym devices.
2. mobility_data/management/commands/import_outdoor_gym_devices.py
    * Add importer for outdoor gym devices.
3. mobility_data/management/commands/import_mobility_data.py
    * Add outdoor gym devices.
#### Other
 1. mobility_data/README.md
     * Add info about outdoor gym devices.
2. mobility_data/management/commands/import_outdoor_gym_devices.py
    * Add task to import outdoor gym devices.