### PR TITLE
Feature/playgrounds importer

### DIFF
--- a/mobility_data/README.md
+++ b/mobility_data/README.md
@@ -165,6 +165,12 @@ To import data type:
 ./manage.py import_wfs BarbecuePlace
 ```
 
+
+### Playgrounds
+```
+./manage.py import_wfs PlayGround
+```
+
 ### Föli park and ride stop
 Imports park and ride stops for bikes and cars.
 ```

--- a/mobility_data/importers/data/wfs_importer_config.yml
+++ b/mobility_data/importers/data/wfs_importer_config.yml
@@ -1,4 +1,40 @@
 features:
+  - content_type_name: PlayGround
+    content_type_description: Playgrounds in the city of Turku.
+    wfs_layer: GIS:Viheralueet
+    max_features: 50000
+    include:
+      Kayttotyyppi: Leikkipaikka
+    fields:
+      name:
+        fi: Tunnus
+    extra_fields:
+      kayttotyyppi:
+        wfs_field: Kayttotyyppi
+      omistaja:
+        wfs_field: Omistaja
+      haltija:
+        wfs_field: Haltija
+      kunnossapitaja:
+        wfs_field: Kunnossapitaja
+      hoitaja:
+        wfs_field: Hoitaja
+      alueUrakkaAlue: 
+        wfs_field: AlueUrakkaAlue
+      kunnossapitoluokka:
+        wfs_field: Kunnossapitoluokka
+      talvikunnossapito:
+        wfs_field: Talvikunnossapito
+      pintamateriaali:
+        wfs_field: Pintamateriaali
+      laskettuPintaAla:
+        wfs_field: LaskettuPintaAla
+        wfs_type: double
+      valmistusvuosi:
+        wfs_field: Valmistusvuosi
+      peruskorjausvuosi:
+        wfs_field: Peruskorjausvuosi
+
   - content_type_name: BarbecuePlace
     content_type_description: Barbecue places in the city of Turku.
     wfs_layer: GIS:Varusteet

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -47,6 +47,11 @@ def import_barbecue_places(name="import_barbecue_places"):
 
 
 @shared_task
+def import_playgrounds(name="import_playgrounds"):
+    management.call_command("import_wfs", ["PlayGround"])
+
+
+@shared_task
 def import_share_car_parking_places(name="impor_share_car_parking_places"):
     management.call_command("import_share_car_parking_places")
 


### PR DESCRIPTION
# Playground importer


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. mobility_data/README.md
    * Add info about importing playgrounds.
2. mobility_data/importers/data/wfs_importer_config.yml
    * Add configuration for playgrounds.
3. mobility_data/tasks.py
    * Add task that imports playgrounds.