### PR TITLE
Feature/mobile unit list bbox param

### DIFF
--- a/bicycle_network/api/views.py
+++ b/bicycle_network/api/views.py
@@ -82,11 +82,13 @@ class BicycleNetworkPartViewSet(viewsets.ReadOnlyModelViewSet):
             )
         # Return elements that are inside bbox
         if "bbox" in filters:
-            ref = SpatialReference(4326)
-            val = self.request.query_params.get("bbox", None)
-            bbox_filter = munigeo_api.build_bbox_filter(ref, val, "geometry")
-            bbox_geometry_filter = munigeo_api.build_bbox_filter(ref, val, "geometry")
-            queryset = queryset.filter(Q(**bbox_filter) | Q(**bbox_geometry_filter))
+            val = filters.get("bbox", None)
+            if val:
+                ref = SpatialReference(filters.get("bbox_srid", 4326))
+                bbox_geometry_filter = munigeo_api.build_bbox_filter(
+                    ref, val, "geometry"
+                )
+                queryset = queryset.filter(Q(**bbox_geometry_filter))
 
         page = self.paginate_queryset(queryset)
         if only_coords:

--- a/mobility_data/api/views.py
+++ b/mobility_data/api/views.py
@@ -1,6 +1,9 @@
 from distutils.util import strtobool
 
+from django.contrib.gis.gdal import SpatialReference
 from django.core.exceptions import ValidationError
+from django.db.models import Q
+from munigeo import api as munigeo_api
 from rest_framework import status, viewsets
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
@@ -190,6 +193,15 @@ class MobileUnitViewSet(viewsets.ReadOnlyModelViewSet):
             queryset = MobileUnit.objects.filter(content_type__name=type_name)
         else:
             queryset = MobileUnit.objects.all()
+
+        if "bbox" in filters:
+            val = filters.get("bbox", None)
+            if val:
+                ref = SpatialReference(filters.get("bbox_srid", 4326))
+                bbox_geometry_filter = munigeo_api.build_bbox_filter(
+                    ref, val, "geometry"
+                )
+                queryset = queryset.filter(Q(**bbox_geometry_filter))
 
         for filter in filters:
             if filter.startswith("extra__"):

--- a/mobility_data/specification.swagger2.0.yaml
+++ b/mobility_data/specification.swagger2.0.yaml
@@ -134,6 +134,9 @@ paths:
         - $ref: "#/components/parameters/latlon_param"
         - $ref: "#/components/parameters/type_name_param"
         - $ref: "#/components/parameters/extra_param"
+        - $ref: "#/components/parameters/bbox_param"
+        - $ref: "#/components/parameters/bbox_srid_param"
+
       responses:
         200:
           description: "List of MobileUnits."
@@ -287,3 +290,24 @@ components:
       schema:
         type: string
       example: extra__fieldname=value
+
+    bbox_param:
+      name: bbox
+      in: query
+      description: Search for mobile units that are within this bounding box. Decimal coordinates
+        are given in order west, south, east, north. Period is used as decimal
+        separator. Default srid is 4326.
+      schema:
+        type: array
+        items:
+          type: number
+      example: 24.9405559,60.1695096,24.9805559,60.1895096
+    
+    bbox_srid_param:
+      name: bbox_srid
+        in: query
+        description: An SRID coordinate reference system identifier which specifies the
+          coordinate system used in the bbox parameter. 
+        schema:
+          type: integer
+        example: 3046

--- a/mobility_data/tests/conftest.py
+++ b/mobility_data/tests/conftest.py
@@ -66,11 +66,13 @@ def group_type():
 @pytest.fixture
 def mobile_unit(content_type):
     extra = {"test_int": 4242, "test_float": 42.42, "test_string": "4242"}
+    geometry = Point(22.21, 60.3, srid=4326)
+    geometry.transform(settings.DEFAULT_SRID)
     mobile_unit = MobileUnit.objects.create(
         name="Test mobileunit",
         description="Test description",
         content_type=content_type,
-        geometry=Point(42.42, 21.21, srid=settings.DEFAULT_SRID),
+        geometry=geometry,
         extra=extra,
     )
     return mobile_unit

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -36,7 +36,9 @@ def test_mobile_unit(api_client, mobile_unit, content_type):
     assert results["extra"]["test_string"] == "4242"
     assert results["extra"]["test_int"] == 4242
     assert results["extra"]["test_float"] == 42.42
-    assert results["geometry"] == Point(42.42, 21.21, srid=settings.DEFAULT_SRID)
+    assert results["geometry"] == Point(
+        235404.6706163187, 6694437.919005549, srid=settings.DEFAULT_SRID
+    )
     url = (
         reverse("mobility_data:mobile_units-list")
         + "?type_name=Test?extra__test_string=4242"
@@ -63,6 +65,17 @@ def test_mobile_unit(api_client, mobile_unit, content_type):
     assert response.status_code == 200
     results = response.json()["results"][0]
     assert results["name"] == "Test mobileunit"
+    # Test that we get a mobile unit inside bbox.
+    url = (
+        reverse("mobility_data:mobile_units-list")
+        + "?bbox=21.1,59.2,22.3,61.4&bbox_srid=4326"
+    )
+    response = api_client.get(url)
+    assert len(response.json()["results"]) == 1
+    # Test bbox where no mobile units are inside.
+    url = reverse("mobility_data:mobile_units-list") + "?bbox=22.1,60.2,2.3,60.4"
+    response = api_client.get(url)
+    assert len(response.json()["results"]) == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# Add bbox param to mobile units list view


-----------------------------------------------------------------------------------------------
### Breakdown:

#### API
1. bicycle_network/api/views.py
    * Remove useless filter.
2. mobility_data/api/views.py
    * Add bbox param to mobile unit list view.
#### Tests
1. mobility_data/tests/conftest.py
    * Fix mobile unit geometry srid.
2. mobility_data/tests/test_api.py
    * Add tests for bbox param.
#### Documentation
1. mobility_data/specification.swagger2.0.yaml
    * Add info about bbox and bbox_srid params.