### PR TITLE
Feature/mobile unit query extra with bool values and fix faulty api tests

### DIFF
--- a/mobility_data/api/views.py
+++ b/mobility_data/api/views.py
@@ -224,10 +224,14 @@ class MobileUnitViewSet(viewsets.ReadOnlyModelViewSet):
                             f"extra field '{key}' does not exist",
                             status=status.HTTP_400_BAD_REQUEST,
                         )
+
                     if field_type == float:
                         value = float(value)
                     elif field_type == int:
                         value = int(value)
+                    elif field_type == bool:
+                        value = strtobool(value)
+                        value = bool(value)
                     queryset = queryset.filter(**{filter: value})
 
         page = self.paginate_queryset(queryset)

--- a/mobility_data/tests/conftest.py
+++ b/mobility_data/tests/conftest.py
@@ -70,7 +70,12 @@ def group_type():
 @pytest.fixture
 def mobile_units(content_types):
     mobile_units = []
-    extra = {"test_int": 4242, "test_float": 42.42, "test_string": "4242"}
+    extra = {
+        "test_int": 4242,
+        "test_float": 42.42,
+        "test_string": "4242",
+        "test_bool": False,
+    }
     geometry = Point(22.21, 60.3, srid=4326)
     geometry.transform(settings.DEFAULT_SRID)
     mobile_unit = MobileUnit.objects.create(
@@ -81,10 +86,17 @@ def mobile_units(content_types):
     )
     mobile_unit.content_types.add(content_types[0])
     mobile_units.append(mobile_units)
+    extra = {
+        "test_int": 14,
+        "test_float": 2.4,
+        "test_string": "hello",
+        "test_bool": True,
+    }
     mobile_unit = MobileUnit.objects.create(
         name="Test2 mobileunit",
         description="Test2 description",
         geometry=Point(43.43, 22.22, srid=settings.DEFAULT_SRID),
+        extra=extra,
     )
     mobile_unit.content_types.add(content_types[0])
     mobile_unit.content_types.add(content_types[1])

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -44,32 +44,42 @@ def test_mobile_unit(api_client, mobile_units, content_types):
     assert len(result["content_types"]) == 2
     assert result["content_types"][0]["name"] == "Test"
     assert result["content_types"][1]["name"] == "Test2"
+    # Test string in extra field
     url = (
         reverse("mobility_data:mobile_units-list")
-        + "?type_name=Test?extra__test_string=4242"
+        + "?type_name=Test&extra__test_string=4242"
     )
     response = api_client.get(url)
     assert response.status_code == 200
-    result = response.json()["results"][1]
-    assert result["name"] == "Test mobileunit"
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"][0]["name"] == "Test mobileunit"
     # Test int value in extra field
     url = (
         reverse("mobility_data:mobile_units-list")
-        + "?type_name=Test?extra__test_int=4242"
+        + "?type_name=Test&extra__test_int=4242"
     )
     response = api_client.get(url)
     assert response.status_code == 200
-    result = response.json()["results"][1]
-    assert result["name"] == "Test mobileunit"
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"][0]["name"] == "Test mobileunit"
     # Test float value in extra field
     url = (
         reverse("mobility_data:mobile_units-list")
-        + "?type_name=Test?extra__test_float=42.42"
+        + "?type_name=Test&extra__test_float=42.42"
     )
     response = api_client.get(url)
     assert response.status_code == 200
-    result = response.json()["results"][1]
-    assert result["name"] == "Test mobileunit"
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"][0]["name"] == "Test mobileunit"
+    # Test vool value in extra field
+    url = (
+        reverse("mobility_data:mobile_units-list")
+        + "?type_name=Test&extra__test_bool=True"
+    )
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"][0]["name"] == "Test2 mobileunit"
     # Test that we get a mobile unit inside bbox.
     url = (
         reverse("mobility_data:mobile_units-list")


### PR DESCRIPTION
# Add support for bool value when retrieving data with extra param. Fix faulty API tests.



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changes
1. mobility_data/api/views.py
    * Add support for bool value to extra__ param.
2. mobility_data/tests/conftest.py
    * Add extra field with identical keys to the mobile unit(same content type).
3. mobility_data/tests/test_api.py 
    * Fix faulty tests and add test for bool extra value