### PR TITLE
Bugfix/swedish school districts not imported

### DIFF
--- a/smbackend_turku/importers/data/divisions_config.yml
+++ b/smbackend_turku/importers/data/divisions_config.yml
@@ -79,6 +79,7 @@ divisions:
     name: "Oppilaaksiottoalue, ruotsinkielinen alakoulu"   
     ocd_id: oppilaaksiottoalue_alakoulu_sv
     wfs_layer: 'GIS:Oppilasalueet_ruotsi_1-6'
+    check_turku_boundary: False
     fields:
       name:
         sv: Oppilasalueen_kuvaus
@@ -89,6 +90,7 @@ divisions:
     name: "Oppilaaksiottoalue, ruotsinkielinen yläkoulu"  
     ocd_id: oppilaaksiottoalue_ylakoulu_sv
     wfs_layer: 'GIS:Oppilasalueet_ruotsi_7-9'
+    check_turku_boundary: False
     fields:
       name:
         sv: Oppilasalueen_kuvaus

--- a/smbackend_turku/importers/divisions.py
+++ b/smbackend_turku/importers/divisions.py
@@ -46,9 +46,7 @@ class DivisionImporter:
         self.muni_data_path = "data"
 
     def _import_division(self, muni, div, type_obj, syncher, parent_dict, feat):
-        check_turku_boundary = True
-        if "check_turku_boundary" in div:
-            check_turku_boundary = div["check_turku_boundary"]
+        check_turku_boundary = div.get("check_turku_boundary", True)
         geom = feat.geom
         if not geom.srid:
             geom.srid = SOURCE_DATA_SRID


### PR DESCRIPTION
# Fix bug, swedish school district not imported


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. smbackend_turku/importers/data/divisions_config.yml
    * Do not check the boundarys of Turku for swedish school districts
2. smbackend_turku/importers/divisions.py
    * Get check_turku_boundary value with default value
