### PR TITLE
Bugfix/kuntec street maintenance history importer not working

### DIFF
--- a/street_maintenance/management/commands/constants.py
+++ b/street_maintenance/management/commands/constants.py
@@ -131,6 +131,7 @@ EVENT_MAPPINGS = {
     "liikennemerkkien puhdistus": [MUUT],
     "siirtoajo": [MUUT],
     "Kelintarkastus": [MUUT],
+    "Sulamisvesien hallinta / höyrytys": [MUUT],
 }
 TIMESTAMP_FORMATS = {
     INFRAROAD: "%Y-%m-%d %H:%M:%S",

--- a/street_maintenance/management/commands/import_kuntec_street_maintenance_history.py
+++ b/street_maintenance/management/commands/import_kuntec_street_maintenance_history.py
@@ -92,7 +92,7 @@ class Command(BaseImportCommand):
                                 continue
                             timestamp = route["start"]["time"]
 
-                            obj, created = MaintenanceWork.get_or_create(
+                            obj, created = MaintenanceWork.objects.get_or_create(
                                 timestamp=timestamp,
                                 maintenance_unit=unit,
                                 events=events,


### PR DESCRIPTION
# fix bug, kuntec street maintenance history importer not working



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed 
1. street_maintenance/management/commands/constants.py
    * Add event named 'Sulamisvesien hallinta / höyrytys'
2. street_maintenance/management/commands/import_kuntec_street_maintenance_history.py
    * Add objects manager when calling get_or_create