### PR TITLE
Feature/street maintenance history importer tests

### DIFF
--- a/street_maintenance/management/commands/constants.py
+++ b/street_maintenance/management/commands/constants.py
@@ -146,6 +146,12 @@ TIMESTAMP_FORMATS = {
     KUNTEC: "%Y-%m-%dT%H:%M:%SZ",
     YIT: "%Y-%m-%d %H:%M:%S%z",
 }
+DATE_FORMATS = {
+    INFRAROAD: "%Y-%m-%d",
+    DESTIA: "%Y-%m-%d",
+    KUNTEC: "%Y-%m-%d",
+    YIT: "%Y-%m-%d",
+}
 # GeometryHistory API list start_date_time parameter format.
 START_DATE_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 # The number of works(point data with a timestamp and events) to be fetched for every unit.

--- a/street_maintenance/tests/conftest.py
+++ b/street_maintenance/tests/conftest.py
@@ -75,7 +75,7 @@ def geometry_historys():
     geometry_historys.append(obj) 
     
     
-@ pytest.mark.django_db
+@pytest.mark.django_db
 @pytest.fixture
 def administrative_division_type():
     adm_div_type = AdministrativeDivisionType.objects.create(

--- a/street_maintenance/tests/conftest.py
+++ b/street_maintenance/tests/conftest.py
@@ -2,9 +2,15 @@ from datetime import datetime, timedelta
 
 import pytest
 import pytz
-from django.contrib.gis.geos import LineString
+from django.contrib.gis.geos import GEOSGeometry, LineString
+from munigeo.models import (
+    AdministrativeDivision,
+    AdministrativeDivisionGeometry,
+    AdministrativeDivisionType,
+)
 from rest_framework.test import APIClient
 
+from mobility_data.tests.conftest import TURKU_WKT
 from street_maintenance.management.commands.constants import (
     AURAUS,
     INFRAROAD,
@@ -69,5 +75,31 @@ def geometry_historys():
         provider=KUNTEC,
         events=[AURAUS, LIUKKAUDENTORJUNTA],
     )
-    geometry_historys.append(obj)
-    return geometry_historys
+    geometry_historys.append(obj) @ pytest.mark.django_db
+
+
+@pytest.fixture
+def administrative_division_type():
+    adm_div_type = AdministrativeDivisionType.objects.create(
+        id=1, type="muni", name="Municipality"
+    )
+    return adm_div_type
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def administrative_division(administrative_division_type):
+    adm_div = AdministrativeDivision.objects.get_or_create(
+        id=1, name="Turku", origin_id=853, type_id=1
+    )
+    return adm_div
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def administrative_division_geometry(administrative_division):
+    turku_multipoly = GEOSGeometry(TURKU_WKT, srid=3067)
+    adm_div_geom = AdministrativeDivisionGeometry.objects.create(
+        id=1, division_id=1, boundary=turku_multipoly
+    )
+    return adm_div_geom

--- a/street_maintenance/tests/conftest.py
+++ b/street_maintenance/tests/conftest.py
@@ -49,7 +49,6 @@ def geometry_historys():
         events=[AURAUS],
     )
     geometry_historys.append(obj)
-
     obj = GeometryHistory.objects.create(
         timestamp=now - timedelta(days=2),
         geometry=geometry,
@@ -58,7 +57,6 @@ def geometry_historys():
         events=[LIUKKAUDENTORJUNTA],
     )
     geometry_historys.append(obj)
-
     obj = GeometryHistory.objects.create(
         timestamp=now - timedelta(days=1),
         geometry=geometry,
@@ -66,7 +64,6 @@ def geometry_historys():
         provider=KUNTEC,
         events=[AURAUS],
     )
-
     geometry_historys.append(obj)
     obj = GeometryHistory.objects.create(
         timestamp=now - timedelta(days=2),
@@ -75,9 +72,10 @@ def geometry_historys():
         provider=KUNTEC,
         events=[AURAUS, LIUKKAUDENTORJUNTA],
     )
-    geometry_historys.append(obj) @ pytest.mark.django_db
-
-
+    geometry_historys.append(obj) 
+    
+    
+@ pytest.mark.django_db
 @pytest.fixture
 def administrative_division_type():
     adm_div_type = AdministrativeDivisionType.objects.create(

--- a/street_maintenance/tests/conftest.py
+++ b/street_maintenance/tests/conftest.py
@@ -72,9 +72,9 @@ def geometry_historys():
         provider=KUNTEC,
         events=[AURAUS, LIUKKAUDENTORJUNTA],
     )
-    geometry_historys.append(obj) 
-    
-    
+    geometry_historys.append(obj)
+
+
 @pytest.mark.django_db
 @pytest.fixture
 def administrative_division_type():

--- a/street_maintenance/tests/test_importers.py
+++ b/street_maintenance/tests/test_importers.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from street_maintenance.management.commands.constants import DATE_FORMATS, INFRAROAD
+from street_maintenance.models import MaintenanceUnit, MaintenanceWork
+
+
+def get_infraroad_works_json_data(num_elements):
+    current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
+    location_history = [
+        {
+            "timestamp": f"{current_date} 08:29:49",
+            "coords": "(22.24957474 60.49515401)",
+            "events": ["au"],
+        },
+        {
+            "timestamp": f"{current_date} 08:29:28",
+            "coords": "(22.24946401 60.49515848)",
+            "events": ["au"],
+        },
+        {
+            "timestamp": f"{current_date} 08:28:32",
+            "coords": "(22.24944127 60.49519463)",
+            "events": ["hiekoitus"],
+        },
+    ]
+    assert num_elements <= len(location_history)
+    data = {"location_history": location_history[:num_elements]}
+    return data
+
+
+def get_infraroad_units_json_data(num_elements):
+    current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
+    data = [
+        {
+            "id": 2817625,
+            "last_location": {
+                "timestamp": f"{current_date} 06:31:34",
+                "coords": "(22.249642023816705 60.49569119699299)",
+                "events": ["au"],
+            },
+        },
+        {
+            "id": 12891825,
+            "last_location": {
+                "timestamp": f"{current_date} 08:29:49",
+                "coords": "(22.24957474 60.49515401)",
+                "events": ["Kenttien hoito"],
+            },
+        },
+    ]
+    assert num_elements <= len(data)
+    return data[:num_elements]
+
+
+@pytest.mark.django_db
+@patch("street_maintenance.management.commands.utils.get_json_data")
+def test_infraroad(
+    get_json_data_mock, administrative_division, administrative_division_geometry
+):
+    from street_maintenance.management.commands.utils import (
+        create_maintenance_units,
+        create_maintenance_works,
+    )
+
+    # Test unit creation
+    get_json_data_mock.return_value = get_infraroad_units_json_data(2)
+    num_created_units, num_del_units = create_maintenance_units(INFRAROAD)
+    assert MaintenanceUnit.objects.count() == 2
+    assert num_created_units == 2
+    assert num_del_units == 0
+    unit = MaintenanceUnit.objects.first()
+    unit.unit_id = "2817625"
+    unit.names = ["au"]
+    get_json_data_mock.return_value = get_infraroad_units_json_data(1)
+    num_created_units, num_del_units = create_maintenance_units(INFRAROAD)
+    assert unit.id == MaintenanceUnit.objects.first().id
+    assert num_created_units == 0
+    assert num_del_units == 1
+    assert MaintenanceUnit.objects.count() == 1
+    get_json_data_mock.return_value = get_infraroad_works_json_data(3)
+    num_created_works, num_del_works = create_maintenance_works(INFRAROAD, 1, 10)
+    assert num_created_works == 3
+    assert num_del_works == 0
+    assert MaintenanceWork.objects.count() == 3
+    work = MaintenanceWork.objects.first()
+    work.events = ["auraus"]
+    work.original_event_names = ["au"]
+    get_json_data_mock.return_value = get_infraroad_works_json_data(1)
+    num_created_works, num_del_works = create_maintenance_works(INFRAROAD, 1, 10)
+    assert num_created_works == 0
+    assert num_del_works == 2
+    assert work.id == MaintenanceWork.objects.first().id
+    assert MaintenanceWork.objects.count() == 1

--- a/street_maintenance/tests/test_importers.py
+++ b/street_maintenance/tests/test_importers.py
@@ -1,58 +1,58 @@
-from datetime import datetime
 from unittest.mock import patch
 
 import pytest
 
-from street_maintenance.management.commands.constants import DATE_FORMATS, INFRAROAD
+from street_maintenance.management.commands.constants import INFRAROAD
 from street_maintenance.models import MaintenanceUnit, MaintenanceWork
 
-
-def get_infraroad_works_json_data(num_elements):
-    current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
-    location_history = [
-        {
-            "timestamp": f"{current_date} 08:29:49",
-            "coords": "(22.24957474 60.49515401)",
-            "events": ["au"],
-        },
-        {
-            "timestamp": f"{current_date} 08:29:28",
-            "coords": "(22.24946401 60.49515848)",
-            "events": ["au"],
-        },
-        {
-            "timestamp": f"{current_date} 08:28:32",
-            "coords": "(22.24944127 60.49519463)",
-            "events": ["hiekoitus"],
-        },
-    ]
-    assert num_elements <= len(location_history)
-    data = {"location_history": location_history[:num_elements]}
-    return data
+from .utils import (
+    get_infraroad_units_json_data,
+    get_infraroad_works_json_data,
+    get_kuntec_units_json_data,
+    get_kuntec_works_json_data,
+)
 
 
-def get_infraroad_units_json_data(num_elements):
-    current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
-    data = [
-        {
-            "id": 2817625,
-            "last_location": {
-                "timestamp": f"{current_date} 06:31:34",
-                "coords": "(22.249642023816705 60.49569119699299)",
-                "events": ["au"],
-            },
-        },
-        {
-            "id": 12891825,
-            "last_location": {
-                "timestamp": f"{current_date} 08:29:49",
-                "coords": "(22.24957474 60.49515401)",
-                "events": ["Kenttien hoito"],
-            },
-        },
-    ]
-    assert num_elements <= len(data)
-    return data[:num_elements]
+@pytest.mark.django_db
+@patch("street_maintenance.management.commands.utils.get_json_data")
+def test_kuntec(
+    get_json_data_mock, administrative_division, administrative_division_geometry
+):
+    from street_maintenance.management.commands.utils import (
+        create_kuntec_maintenance_units,
+        create_kuntec_maintenance_works,
+    )
+
+    # Note, the fixture JSON contains one unit item with IO_DIN state 0(off)
+    # i.e., will not be included
+    get_json_data_mock.return_value = get_kuntec_units_json_data(2)
+    num_created_units, num_del_units = create_kuntec_maintenance_units()
+    assert num_created_units == 2
+    assert num_del_units == 0
+    assert MaintenanceUnit.objects.count() == 2
+    unit = MaintenanceUnit.objects.first()
+    assert unit.unit_id == "150635"
+    assert unit.names == ["Auraus"]
+    get_json_data_mock.return_value = get_kuntec_units_json_data(1)
+    num_created_units, num_del_units = create_kuntec_maintenance_units()
+    assert unit.id == MaintenanceUnit.objects.first().id
+    assert num_created_units == 0
+    assert num_del_units == 1
+    assert MaintenanceUnit.objects.count() == 1
+    get_json_data_mock.return_value = get_kuntec_works_json_data(2)
+    num_created_works, num_del_works = create_kuntec_maintenance_works(3)
+    assert num_created_works == 2
+    assert num_del_works == 0
+    assert MaintenanceWork.objects.count() == 2
+    work = MaintenanceWork.objects.first()
+    work.events = ["auraus"]
+    work.original_event_names = ["Auraus"]
+    get_json_data_mock.return_value = get_kuntec_works_json_data(1)
+    num_created_works, num_del_works = create_kuntec_maintenance_works(3)
+    assert num_created_works == 0
+    assert num_del_works == 1
+    assert work.id == MaintenanceWork.objects.first().id
+    assert MaintenanceWork.objects.count() == 1
 
 
 @pytest.mark.django_db

--- a/street_maintenance/tests/test_importers.py
+++ b/street_maintenance/tests/test_importers.py
@@ -6,11 +6,90 @@ from street_maintenance.management.commands.constants import INFRAROAD
 from street_maintenance.models import MaintenanceUnit, MaintenanceWork
 
 from .utils import (
-    get_infraroad_units_json_data,
-    get_infraroad_works_json_data,
-    get_kuntec_units_json_data,
-    get_kuntec_works_json_data,
+    get_infraroad_units_mock_data,
+    get_infraroad_works_mock_data,
+    get_kuntec_units_mock_data,
+    get_kuntec_works_mock_data,
+    get_yit_contract_mock_data,
+    get_yit_event_types_mock_data,
+    get_yit_routes_mock_data,
+    get_yit_vehicles_mock_data,
 )
+
+
+@pytest.mark.django_db
+@patch("street_maintenance.management.commands.utils.get_yit_vehicles")
+def test_yit_units(
+    get_yit_vehicles_mock,
+    administrative_division,
+    administrative_division_geometry,
+):
+    from street_maintenance.management.commands.utils import (
+        create_yit_maintenance_units,
+    )
+
+    get_yit_vehicles_mock.return_value = get_yit_vehicles_mock_data(2)
+    num_created_units, num_del_units = create_yit_maintenance_units("test_access_token")
+    assert MaintenanceUnit.objects.count() == 2
+    assert num_created_units == 2
+    assert num_del_units == 0
+    unit = MaintenanceUnit.objects.first()
+    unit_id = unit.id
+    assert unit.names == ["Huoltoauto"]
+    assert unit.unit_id == "82260ff7-589e-4cee-a8e0-124b615381f1"
+    get_yit_vehicles_mock.return_value = get_yit_vehicles_mock_data(1)
+    num_created_units, num_del_units = create_yit_maintenance_units("test_access_token")
+    assert unit.id == unit_id
+    assert num_created_units == 0
+    assert num_del_units == 1
+    assert MaintenanceUnit.objects.count() == 1
+
+
+@pytest.mark.django_db
+@patch(
+    "street_maintenance.management.commands.utils.get_yit_vehicles",
+    return_value=get_yit_vehicles_mock_data(2),
+)
+@patch(
+    "street_maintenance.management.commands.utils.get_yit_contract",
+    return_value=get_yit_contract_mock_data(),
+)
+@patch(
+    "street_maintenance.management.commands.utils.get_yit_event_types",
+    return_value=get_yit_event_types_mock_data(),
+)
+@patch("street_maintenance.management.commands.utils.get_yit_routes")
+def test_yit_works(
+    get_yit_routes_mock,
+    get_yit_vechiles_mock,
+    administrative_division,
+    administrative_division_geometry,
+):
+    from street_maintenance.management.commands.utils import (
+        create_yit_maintenance_units,
+        create_yit_maintenance_works,
+    )
+
+    create_yit_maintenance_units("test_access_token")
+    get_yit_routes_mock.return_value = get_yit_routes_mock_data(2)
+    num_created_works, num_del_works = create_yit_maintenance_works(
+        "test_access_token", 3
+    )
+    assert num_created_works == 2
+    assert num_del_works == 0
+    assert MaintenanceWork.objects.count() == 2
+    work = MaintenanceWork.objects.first()
+    work_id = work.id
+    assert work.events == ["liukkaudentorjunta"]
+    assert work.original_event_names == ["Suolaus"]
+    get_yit_routes_mock.return_value = get_yit_routes_mock_data(1)
+    num_created_works, num_del_works = create_yit_maintenance_works(
+        "test_access_token", 3
+    )
+    assert num_created_works == 0
+    assert num_del_works == 1
+    assert work.id == work_id
+    assert MaintenanceWork.objects.count() == 1
 
 
 @pytest.mark.django_db
@@ -25,33 +104,35 @@ def test_kuntec(
 
     # Note, the fixture JSON contains one unit item with IO_DIN state 0(off)
     # i.e., will not be included
-    get_json_data_mock.return_value = get_kuntec_units_json_data(2)
+    get_json_data_mock.return_value = get_kuntec_units_mock_data(2)
     num_created_units, num_del_units = create_kuntec_maintenance_units()
     assert num_created_units == 2
     assert num_del_units == 0
     assert MaintenanceUnit.objects.count() == 2
     unit = MaintenanceUnit.objects.first()
+    unit_id = unit.id
     assert unit.unit_id == "150635"
     assert unit.names == ["Auraus"]
-    get_json_data_mock.return_value = get_kuntec_units_json_data(1)
+    get_json_data_mock.return_value = get_kuntec_units_mock_data(1)
     num_created_units, num_del_units = create_kuntec_maintenance_units()
-    assert unit.id == MaintenanceUnit.objects.first().id
+    assert unit.id == unit_id
     assert num_created_units == 0
     assert num_del_units == 1
     assert MaintenanceUnit.objects.count() == 1
-    get_json_data_mock.return_value = get_kuntec_works_json_data(2)
+    get_json_data_mock.return_value = get_kuntec_works_mock_data(2)
     num_created_works, num_del_works = create_kuntec_maintenance_works(3)
     assert num_created_works == 2
     assert num_del_works == 0
     assert MaintenanceWork.objects.count() == 2
     work = MaintenanceWork.objects.first()
+    work_id = work.id
     work.events = ["auraus"]
     work.original_event_names = ["Auraus"]
-    get_json_data_mock.return_value = get_kuntec_works_json_data(1)
+    get_json_data_mock.return_value = get_kuntec_works_mock_data(1)
     num_created_works, num_del_works = create_kuntec_maintenance_works(3)
     assert num_created_works == 0
     assert num_del_works == 1
-    assert work.id == MaintenanceWork.objects.first().id
+    assert work.id == work_id
     assert MaintenanceWork.objects.count() == 1
 
 
@@ -66,31 +147,33 @@ def test_infraroad(
     )
 
     # Test unit creation
-    get_json_data_mock.return_value = get_infraroad_units_json_data(2)
+    get_json_data_mock.return_value = get_infraroad_units_mock_data(2)
     num_created_units, num_del_units = create_maintenance_units(INFRAROAD)
     assert MaintenanceUnit.objects.count() == 2
     assert num_created_units == 2
     assert num_del_units == 0
     unit = MaintenanceUnit.objects.first()
+    unit_id = unit.id
     unit.unit_id = "2817625"
     unit.names = ["au"]
-    get_json_data_mock.return_value = get_infraroad_units_json_data(1)
+    get_json_data_mock.return_value = get_infraroad_units_mock_data(1)
     num_created_units, num_del_units = create_maintenance_units(INFRAROAD)
-    assert unit.id == MaintenanceUnit.objects.first().id
+    assert unit.id == unit_id
     assert num_created_units == 0
     assert num_del_units == 1
     assert MaintenanceUnit.objects.count() == 1
-    get_json_data_mock.return_value = get_infraroad_works_json_data(3)
+    get_json_data_mock.return_value = get_infraroad_works_mock_data(3)
     num_created_works, num_del_works = create_maintenance_works(INFRAROAD, 1, 10)
     assert num_created_works == 3
     assert num_del_works == 0
     assert MaintenanceWork.objects.count() == 3
     work = MaintenanceWork.objects.first()
+    work_id = work.id
     work.events = ["auraus"]
     work.original_event_names = ["au"]
-    get_json_data_mock.return_value = get_infraroad_works_json_data(1)
+    get_json_data_mock.return_value = get_infraroad_works_mock_data(1)
     num_created_works, num_del_works = create_maintenance_works(INFRAROAD, 1, 10)
     assert num_created_works == 0
     assert num_del_works == 2
-    assert work.id == MaintenanceWork.objects.first().id
+    assert work.id == work_id
     assert MaintenanceWork.objects.count() == 1

--- a/street_maintenance/tests/utils.py
+++ b/street_maintenance/tests/utils.py
@@ -3,10 +3,115 @@ from datetime import datetime
 from street_maintenance.management.commands.constants import (
     DATE_FORMATS,
     INFRAROAD,
+    YIT,
 )
 
 
-def get_infraroad_works_json_data(num_elements):
+def get_yit_vehicles_mock_data(num_elements):
+    data = [
+        {"id": "82260ff7-589e-4cee-a8e0-124b615381f1", "vehicleTypeName": "Huoltoauto"},
+        {
+            "id": "77396829-6275-4dbe-976f-f9d4f5254653",
+            "vehicleTypeName": "Kuorma-auto",
+        },
+    ]
+    assert num_elements <= len(data)
+    return data[:num_elements]
+
+
+def get_yit_event_types_mock_data():
+    data = [
+        {
+            "id": "a4f6188f-8c25-4f42-89be-f5a1bd7d833a",
+            "operationName": "Auraus ja sohjonpoisto",
+        },
+        {"id": "a51e8e4c-8b16-4132-a882-70f6624c1f2b", "operationName": "Suolaus"},
+    ]
+    return data
+
+
+def get_yit_contract_mock_data():
+    return "d73447e6-df70-4f4a-817d-3387b58aca6c"
+
+
+def get_yit_routes_mock_data(num_elements):
+    current_date = datetime.now().date().strftime(DATE_FORMATS[YIT])
+    data = [
+        {
+            # Note, the MaintenanceUnit is retrieved by the vehicleType
+            "vehicleType": "82260ff7-589e-4cee-a8e0-124b615381f1",
+            "length": 21.0,
+            "geography": {
+                "crs": None,
+                "features": [
+                    {
+                        "geometry": {
+                            "coordinates": [
+                                [22.308685, 60.471465],
+                                [22.308758333333337, 60.47151166666666],
+                                [22.308844999999998, 60.47154999999999],
+                                [22.30887476486449, 60.471557320473416],
+                            ],
+                            "type": "LineString",
+                        },
+                        "properties": {
+                            "streetAddress": "Koroistenkaari, Turku",
+                            "featureType": "StreetAddress",
+                        },
+                        "type": "Feature",
+                    }
+                ],
+                "type": "FeatureCollection",
+            },
+            "created": f"{current_date}T11:50:58.6173037Z",
+            "updated": f"{current_date}T11:50:58.6173037Z",
+            "deleted": False,
+            "id": "aaee2c3b-4296-44b3-aba0-82b859d4eea8",
+            "user": "442a5ab2-d58c-4c22-bae2-bcf55327cde7",
+            "contract": "d73447e6-df70-4f4a-817d-3387b58aca6c",
+            "startTime": f"{current_date}T11:48:44.694Z",
+            "endTime": f"{current_date}T11:48:46.984Z",
+            "operations": ["a51e8e4c-8b16-4132-a882-70f6624c1f2b"],
+        },
+        {
+            "vehicleType": "82260ff7-589e-4cee-a8e0-124b615381f1",
+            "length": 0.0,
+            "geography": {
+                "crs": None,
+                "features": [
+                    {
+                        "geometry": {
+                            "coordinates": [
+                                [22.315554108363656, 60.47901418729062],
+                                [22.31555399713308, 60.47901429688299],
+                            ],
+                            "type": "LineString",
+                        },
+                        "properties": {
+                            "streetAddress": "Polttolaitoksenkatu 13, Turku",
+                            "featureType": "StreetAddress",
+                        },
+                        "type": "Feature",
+                    }
+                ],
+                "type": "FeatureCollection",
+            },
+            "created": f"{current_date}T11:52:00.5136066Z",
+            "updated": f"{current_date}T11:52:00.5136066Z",
+            "deleted": False,
+            "id": "9c566b34-2bb5-46b0-9c0a-99f53eada2d2",
+            "user": "442a5ab2-d58c-4c22-bae2-bcf55327cde7",
+            "contract": "d73447e6-df70-4f4a-817d-3387b58aca6c",
+            "startTime": f"{current_date}T11:50:21.708Z",
+            "endTime": f"{current_date}T11:50:21.709Z",
+            "operations": ["a51e8e4c-8b16-4132-a882-70f6624c1f2b"],
+        },
+    ]
+    assert num_elements <= len(data)
+    return data[:num_elements]
+
+
+def get_infraroad_works_mock_data(num_elements):
     current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
     location_history = [
         {
@@ -30,7 +135,7 @@ def get_infraroad_works_json_data(num_elements):
     return data
 
 
-def get_infraroad_units_json_data(num_elements):
+def get_infraroad_units_mock_data(num_elements):
     current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
     data = [
         {
@@ -54,7 +159,7 @@ def get_infraroad_units_json_data(num_elements):
     return data[:num_elements]
 
 
-def get_kuntec_works_json_data(num_elements):
+def get_kuntec_works_mock_data(num_elements):
     current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
     routes = [
         {
@@ -107,7 +212,7 @@ def get_kuntec_works_json_data(num_elements):
     return data
 
 
-def get_kuntec_units_json_data(num_elements):
+def get_kuntec_units_mock_data(num_elements):
     null = None
     units = [
         {
@@ -148,7 +253,7 @@ def get_kuntec_units_json_data(num_elements):
                 "duration": 151159,
             },
             "fuel_type": "",
-            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"}, # noqa W605
+            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"},  # noqa W605
             "created_at": "2019-11-05T10:10:38Z",
             "io_din": [
                 {"no": 1, "label": "Auraus", "state": 1},
@@ -194,7 +299,7 @@ def get_kuntec_units_json_data(num_elements):
                 "duration": 75995,
             },
             "fuel_type": "",
-            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"}, # noqa W605
+            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"},  # noqa W605
             "created_at": "2019-11-05T10:39:46Z",
             "io_din": [
                 {"no": 1, "label": "Auraus", "state": 1},
@@ -240,7 +345,7 @@ def get_kuntec_units_json_data(num_elements):
                 "duration": 75995,
             },
             "fuel_type": "",
-            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"}, # noqa W605
+            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"},  # noqa W605
             "created_at": "2019-11-05T10:39:46Z",
             "io_din": [
                 {"no": 1, "label": "Auraus", "state": 1},

--- a/street_maintenance/tests/utils.py
+++ b/street_maintenance/tests/utils.py
@@ -1,0 +1,254 @@
+from datetime import datetime
+
+from street_maintenance.management.commands.constants import (
+    DATE_FORMATS,
+    INFRAROAD,
+)
+
+
+def get_infraroad_works_json_data(num_elements):
+    current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
+    location_history = [
+        {
+            "timestamp": f"{current_date} 08:29:49",
+            "coords": "(22.24957474 60.49515401)",
+            "events": ["au"],
+        },
+        {
+            "timestamp": f"{current_date} 08:29:28",
+            "coords": "(22.24946401 60.49515848)",
+            "events": ["au"],
+        },
+        {
+            "timestamp": f"{current_date} 08:28:32",
+            "coords": "(22.24944127 60.49519463)",
+            "events": ["hiekoitus"],
+        },
+    ]
+    assert num_elements <= len(location_history)
+    data = {"location_history": location_history[:num_elements]}
+    return data
+
+
+def get_infraroad_units_json_data(num_elements):
+    current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
+    data = [
+        {
+            "id": 2817625,
+            "last_location": {
+                "timestamp": f"{current_date} 06:31:34",
+                "coords": "(22.249642023816705 60.49569119699299)",
+                "events": ["au"],
+            },
+        },
+        {
+            "id": 12891825,
+            "last_location": {
+                "timestamp": f"{current_date} 08:29:49",
+                "coords": "(22.24957474 60.49515401)",
+                "events": ["Kenttien hoito"],
+            },
+        },
+    ]
+    assert num_elements <= len(data)
+    return data[:num_elements]
+
+
+def get_kuntec_works_json_data(num_elements):
+    current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
+    routes = [
+        {
+            "route_id": 3980827390,
+            "type": "route",
+            "start": {
+                "time": f"{current_date}T14:54:31Z",
+                "address": "M\u00e4likk\u00e4l\u00e4, 21280 Turku, Suomi",
+                "lat": 60.47185,
+                "lng": 22.21618,
+            },
+            "avg_speed": 18,
+            "max_speed": 43,
+            "end": {
+                "time": f"{current_date}T15:05:56Z",
+                "address": "Ihalantie 7, 21200 Raisio, Suomi",
+                "lat": 60.47945,
+                "lng": 22.18221,
+            },
+            "distance": 3565,
+            "polyline": "a|apJcbrfC@HEpQYdEi@rDeAnE{Sji@eOjp@qEpb@uUlkA?T@TFRHLNDb@@b@Cd@Sb@i@XeArCeJv@{@z@c@h@E~@JdC"
+            + "n@FCBE@C@G@G@K?KEsA@cBAI?K?}BBWF[DOBMJQBCB?D?JHFHDN@FBNBLBD@BDBES?EAEAEI[CM@EXt@Uw@Tz@BHA?EQEMO_@@HIII"
+            + "IAE?QAc@EXCECBEDAHWdBENAF?D?D?v@DhE@JCQ?M@M?_@@oFBKF]",
+        },
+        {
+            "route_id": 3984019243,
+            "type": "route",
+            "start": {
+                "time": f"{current_date}T11:16:00Z",
+                "address": "Tuontikatu 180, 20200 Turku, Suomi",
+                "lat": 60.44447,
+                "lng": 22.21462,
+            },
+            "avg_speed": 18,
+            "max_speed": 43,
+            "end": {
+                "time": f"{current_date}T11:21:55Z",
+                "address": "Tuontikatu, 20200 Turku, Suomi",
+                "lat": 60.44754,
+                "lng": 22.21391,
+            },
+            "distance": 1799,
+            "polyline": "}p|oJkxqfCt@|AtAtELT@JFd@d@nBX`AfAlFLl@Rv@xHv[T^p@~@DJ@B?DDPD@KUACCIQUg@i@]q@m@_C{Loi@AUIKCEU"
+            + "_@Oc@{@yCw@aB_BaB_A_@_CI{F[IFGLI^A`@?d@IfCGxA",
+        },
+    ]
+
+    assert num_elements <= len(routes)
+    data = {"data": {"units": [{"routes": routes[:num_elements]}]}}
+    return data
+
+
+def get_kuntec_units_json_data(num_elements):
+    null = None
+    units = [
+        {
+            "unit_id": 150635,
+            "box_id": 27953713,
+            "company_id": 5495,
+            "country_code": "FI",
+            "label": "1100781186",
+            "number": "HAKA 2",
+            "shortcut": "",
+            "vehicle_title": null,
+            "car_reg_certificate": "",
+            "vin": null,
+            "type": "car",
+            "icon": "tractor",
+            "lat": 60.46423,
+            "lng": 22.43703,
+            "direction": 161,
+            "speed": null,
+            "mileage": 11779869,
+            "last_update": "2023-02-25T13:20:56Z",
+            "ignition_total_time": 7683589,
+            "state": {
+                "name": "nodata",
+                "start": "2023-02-25T12:40:53Z",
+                "duration": 148756,
+                "debug_info": {
+                    "boxId": 27953713,
+                    "carId": 150635,
+                    "msg": "POWEROFF",
+                    "lastUpdate": 1677331256,
+                    "lastValues": null,
+                },
+            },
+            "movement_state": {
+                "name": "nodata",
+                "start": "2023-02-25T12:40:53Z",
+                "duration": 151159,
+            },
+            "fuel_type": "",
+            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"}, # noqa W605
+            "created_at": "2019-11-05T10:10:38Z",
+            "io_din": [
+                {"no": 1, "label": "Auraus", "state": 1},
+                {"no": 2, "label": "Hiekoitus", "state": 0},
+                {"no": 3, "label": "Muu ty\u00f6", "state": 0},
+            ],
+        },
+        {
+            "unit_id": 150662,
+            "box_id": 27953746,
+            "company_id": 5495,
+            "country_code": "FI",
+            "label": "1101049692",
+            "number": "TAKKU 1",
+            "shortcut": "",
+            "vehicle_title": null,
+            "car_reg_certificate": "",
+            "vin": null,
+            "type": "car",
+            "icon": "tractor",
+            "lat": 60.55185,
+            "lng": 22.20567,
+            "direction": 213,
+            "speed": null,
+            "mileage": 10537795,
+            "last_update": "2023-02-26T10:02:03Z",
+            "ignition_total_time": 0,
+            "state": {
+                "name": "nodata",
+                "start": "2023-02-26T09:33:37Z",
+                "duration": 74289,
+                "debug_info": {
+                    "boxId": 27953746,
+                    "carId": 150662,
+                    "msg": "OTHER",
+                    "lastUpdate": 1677405723,
+                    "lastValues": {"VOLTAGE": "14289"},
+                },
+            },
+            "movement_state": {
+                "name": "nodata",
+                "start": "2023-02-26T09:33:37Z",
+                "duration": 75995,
+            },
+            "fuel_type": "",
+            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"}, # noqa W605
+            "created_at": "2019-11-05T10:39:46Z",
+            "io_din": [
+                {"no": 1, "label": "Auraus", "state": 1},
+                {"no": 2, "label": "Hiekoitus", "state": 0},
+                {"no": 3, "label": "Muu ty\u00f6", "state": 0},
+            ],
+        },
+        {
+            "unit_id": 150662,
+            "box_id": 27953746,
+            "company_id": 5495,
+            "country_code": "FI",
+            "label": "1101049692",
+            "number": "TAKKU 1",
+            "shortcut": "",
+            "vehicle_title": null,
+            "car_reg_certificate": "",
+            "vin": null,
+            "type": "car",
+            "icon": "tractor",
+            "lat": 60.55185,
+            "lng": 22.20567,
+            "direction": 213,
+            "speed": null,
+            "mileage": 10537795,
+            "last_update": "2023-02-26T10:02:03Z",
+            "ignition_total_time": 0,
+            "state": {
+                "name": "nodata",
+                "start": "2023-02-26T09:33:37Z",
+                "duration": 74289,
+                "debug_info": {
+                    "boxId": 27953746,
+                    "carId": 150662,
+                    "msg": "OTHER",
+                    "lastUpdate": 1677405723,
+                    "lastValues": {"VOLTAGE": "14289"},
+                },
+            },
+            "movement_state": {
+                "name": "nodata",
+                "start": "2023-02-26T09:33:37Z",
+                "duration": 75995,
+            },
+            "fuel_type": "",
+            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"}, # noqa W605
+            "created_at": "2019-11-05T10:39:46Z",
+            "io_din": [
+                {"no": 1, "label": "Auraus", "state": 1},
+                {"no": 2, "label": "Hiekoitus", "state": 0},
+                {"no": 3, "label": "Muu ty\u00f6", "state": 0},
+            ],
+        },
+    ]
+    assert num_elements <= len(units)
+    data = {"data": {"units": units[:num_elements]}}
+    return data

--- a/street_maintenance/tests/utils.py
+++ b/street_maintenance/tests/utils.py
@@ -38,6 +38,39 @@ def get_yit_routes_mock_data(num_elements):
     current_date = datetime.now().date().strftime(DATE_FORMATS[YIT])
     data = [
         {
+            "vehicleType": "82260ff7-589e-4cee-a8e0-124b615381f1",
+            "length": 0.0,
+            "geography": {
+                "crs": None,
+                "features": [
+                    {
+                        "geometry": {
+                            "coordinates": [
+                                [22.315554108363656, 60.47901418729062],
+                                [22.31555399713308, 60.47901429688299],
+                            ],
+                            "type": "LineString",
+                        },
+                        "properties": {
+                            "streetAddress": "Polttolaitoksenkatu 13, Turku",
+                            "featureType": "StreetAddress",
+                        },
+                        "type": "Feature",
+                    }
+                ],
+                "type": "FeatureCollection",
+            },
+            "created": f"{current_date}T11:52:00.5136066Z",
+            "updated": f"{current_date}T11:52:00.5136066Z",
+            "deleted": False,
+            "id": "9c566b34-2bb5-46b0-9c0a-99f53eada2d2",
+            "user": "442a5ab2-d58c-4c22-bae2-bcf55327cde7",
+            "contract": "d73447e6-df70-4f4a-817d-3387b58aca6c",
+            "startTime": f"{current_date}T11:50:21.708Z",
+            "endTime": f"{current_date}T11:50:21.709Z",
+            "operations": ["a51e8e4c-8b16-4132-a882-70f6624c1f2b"],
+        },
+        {
             # Note, the MaintenanceUnit is retrieved by the vehicleType
             "vehicleType": "82260ff7-589e-4cee-a8e0-124b615381f1",
             "length": 21.0,
@@ -73,45 +106,13 @@ def get_yit_routes_mock_data(num_elements):
             "endTime": f"{current_date}T11:48:46.984Z",
             "operations": ["a51e8e4c-8b16-4132-a882-70f6624c1f2b"],
         },
-        {
-            "vehicleType": "82260ff7-589e-4cee-a8e0-124b615381f1",
-            "length": 0.0,
-            "geography": {
-                "crs": None,
-                "features": [
-                    {
-                        "geometry": {
-                            "coordinates": [
-                                [22.315554108363656, 60.47901418729062],
-                                [22.31555399713308, 60.47901429688299],
-                            ],
-                            "type": "LineString",
-                        },
-                        "properties": {
-                            "streetAddress": "Polttolaitoksenkatu 13, Turku",
-                            "featureType": "StreetAddress",
-                        },
-                        "type": "Feature",
-                    }
-                ],
-                "type": "FeatureCollection",
-            },
-            "created": f"{current_date}T11:52:00.5136066Z",
-            "updated": f"{current_date}T11:52:00.5136066Z",
-            "deleted": False,
-            "id": "9c566b34-2bb5-46b0-9c0a-99f53eada2d2",
-            "user": "442a5ab2-d58c-4c22-bae2-bcf55327cde7",
-            "contract": "d73447e6-df70-4f4a-817d-3387b58aca6c",
-            "startTime": f"{current_date}T11:50:21.708Z",
-            "endTime": f"{current_date}T11:50:21.709Z",
-            "operations": ["a51e8e4c-8b16-4132-a882-70f6624c1f2b"],
-        },
     ]
     assert num_elements <= len(data)
     return data[:num_elements]
 
 
-def get_infraroad_works_mock_data(num_elements):
+# Both Destia and Infraroad uses the fluentprogress API
+def get_fluentprogress_works_mock_data(num_elements):
     current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
     location_history = [
         {
@@ -122,7 +123,7 @@ def get_infraroad_works_mock_data(num_elements):
         {
             "timestamp": f"{current_date} 08:29:28",
             "coords": "(22.24946401 60.49515848)",
-            "events": ["au"],
+            "events": ["au", "sivuaura", "sirotin"],
         },
         {
             "timestamp": f"{current_date} 08:28:32",
@@ -135,7 +136,7 @@ def get_infraroad_works_mock_data(num_elements):
     return data
 
 
-def get_infraroad_units_mock_data(num_elements):
+def get_fluentprogress_units_mock_data(num_elements):
     current_date = datetime.now().date().strftime(DATE_FORMATS[INFRAROAD])
     data = [
         {
@@ -253,7 +254,7 @@ def get_kuntec_units_mock_data(num_elements):
                 "duration": 151159,
             },
             "fuel_type": "",
-            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"},  # noqa W605
+            "avg_fuel_consumption": {"norm": 0, "measurement": "l/100km"},
             "created_at": "2019-11-05T10:10:38Z",
             "io_din": [
                 {"no": 1, "label": "Auraus", "state": 1},
@@ -299,7 +300,7 @@ def get_kuntec_units_mock_data(num_elements):
                 "duration": 75995,
             },
             "fuel_type": "",
-            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"},  # noqa W605
+            "avg_fuel_consumption": {"norm": 0, "measurement": "l/100km"},
             "created_at": "2019-11-05T10:39:46Z",
             "io_din": [
                 {"no": 1, "label": "Auraus", "state": 1},
@@ -345,7 +346,7 @@ def get_kuntec_units_mock_data(num_elements):
                 "duration": 75995,
             },
             "fuel_type": "",
-            "avg_fuel_consumption": {"norm": 0, "measurement": "l\/100km"},  # noqa W605
+            "avg_fuel_consumption": {"norm": 0, "measurement": "l/100km"},
             "created_at": "2019-11-05T10:39:46Z",
             "io_din": [
                 {"no": 1, "label": "Auraus", "state": 1},


### PR DESCRIPTION
# Street maintenance history importer tests


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. street_maintenance/management/commands/constants.py
     * Add DATE_FORMATS constant. 
2. street_maintenance/management/commands/utils.py
    * Add function to get JSON data and YIT vehicles. Refactor.
3. street_maintenance/tests/conftest.py
   * Add fixtures for administrative divisions.
4. street_maintenance/tests/test_importers.py
    * Add importer tests.
5. street_maintenance/tests/utils.py
    * Add functions that return mock data for tests.