### PR TITLE
Feature/street maintenance history remove duplicate events

### DIFF
--- a/street_maintenance/management/commands/utils.py
+++ b/street_maintenance/management/commands/utils.py
@@ -170,7 +170,6 @@ def get_linestrings_from_points(objects, queryset, provider):
             prev_geometry = elem.geometry
             points.append(elem.geometry)
             prev_timestamp = elem.timestamp
-
         if len(points) > 1:
             discarded_linestrings += add_geometry_history_objects(
                 objects, points, elem, provider
@@ -276,7 +275,8 @@ def create_yit_maintenance_works(access_token, history_size):
                 for e in EVENT_MAPPINGS[event_name]:
                     # If mapping value is None, the event is not used.
                     if e:
-                        events.append(e)
+                        if e not in events:
+                            events.append(e)
                         original_event_names.append(event_name_mappings[operation])
             else:
                 logger.warning(
@@ -342,7 +342,8 @@ def create_kuntec_maintenance_works(history_size):
                                 for e in EVENT_MAPPINGS[event_name]:
                                     # If mapping value is None, the event is not used.
                                     if e:
-                                        events.append(e)
+                                        if e not in events:
+                                            events.append(e)
                                         original_event_names.append(name)
                             else:
                                 logger.warning(f"Found unmapped event: {event_name}")
@@ -422,7 +423,8 @@ def create_maintenance_works(provider, history_size, fetch_size):
                     for e in EVENT_MAPPINGS[event_name]:
                         # If mapping value is None, the event is not used.
                         if e:
-                            events.append(e)
+                            if e not in events:
+                                events.append(e)
                             original_event_names.append(event)
                 else:
                     logger.warning(f"Found unmapped event: {event}")

--- a/street_maintenance/tests/test_importers.py
+++ b/street_maintenance/tests/test_importers.py
@@ -112,7 +112,7 @@ def test_kuntec(
     unit = MaintenanceUnit.objects.first()
     unit_id = unit.id
     assert unit.unit_id == "150635"
-    assert unit.names == ["Auraus"]
+    assert unit.names == ["Auraus", "Hiekoitus"]
     get_json_data_mock.return_value = get_kuntec_units_mock_data(1)
     num_created_units, num_del_units = create_kuntec_maintenance_units()
     assert unit_id == MaintenanceUnit.objects.first().id
@@ -126,8 +126,8 @@ def test_kuntec(
     assert MaintenanceWork.objects.count() == 2
     work = MaintenanceWork.objects.first()
     work_id = work.id
-    work.events = ["auraus"]
-    work.original_event_names = ["Auraus"]
+    work.events = ["auraus", "liukkaudentorjunta"]
+    work.original_event_names = ["Auraus", "Hiekoitus"]
     get_json_data_mock.return_value = get_kuntec_works_mock_data(1)
     num_created_works, num_del_works = create_kuntec_maintenance_works(3)
     assert num_created_works == 0
@@ -217,7 +217,8 @@ def test_destia(
     work = MaintenanceWork.objects.get(
         original_event_names=["au", "sivuaura", "sirotin"]
     )
-    assert work.events == ["auraus", "auraus", "liukkaudentorjunta"]
+    # Test that duplicate events are not included, as "sivuaura" and "au" are mapped to "auraus"
+    assert work.events == ["auraus", "liukkaudentorjunta"]
     get_json_data_mock.return_value = get_fluentprogress_works_mock_data(1)
     num_created_works, num_del_works = create_maintenance_works(DESTIA, 1, 10)
     assert num_created_works == 0

--- a/street_maintenance/tests/utils.py
+++ b/street_maintenance/tests/utils.py
@@ -258,7 +258,7 @@ def get_kuntec_units_mock_data(num_elements):
             "created_at": "2019-11-05T10:10:38Z",
             "io_din": [
                 {"no": 1, "label": "Auraus", "state": 1},
-                {"no": 2, "label": "Hiekoitus", "state": 0},
+                {"no": 2, "label": "Hiekoitus", "state": 1},
                 {"no": 3, "label": "Muu ty\u00f6", "state": 0},
             ],
         },


### PR DESCRIPTION
# Street maintenance history remove duplicate events

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. street_maintenance/management/commands/utils.py
     * Do not set event if event already exists. 
2. street_maintenance/tests/test_importers.py
    * Add test to check that no duplicate events are created. 
3. street_maintenance/tests/utils.py
   * Add io_din state to 1 for "hiekoitus" to kuntec mock data.