### PR TITLE
delete-mobile-units-function-not-deleting

### DIFF
--- a/mobility_data/importers/utils.py
+++ b/mobility_data/importers/utils.py
@@ -68,7 +68,7 @@ def fetch_json(url):
 
 
 def delete_mobile_units(name):
-    ContentType.objects.filter(name=name).delete()
+    MobileUnit.objects.filter(content_types__name=name).delete()
 
 
 def create_mobile_unit_as_unit_reference(unit_id, content_type):


### PR DESCRIPTION
# Fix bug, delete mobile units not deleting

## Description

The bug resulted in that every mobile unit that was supposed to be deleted was left with the content_types column null.
Caused after changing the content_type to m2m content_types and removal of the CASCADE delete flag.
-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed
 1. mobility_data/importers/utils.py
     * Delete MobileUnit with given content types name
