### PR TITLE
Bugfix/mobile units with unit id not filtered correctly

### DIFF
--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -88,7 +88,7 @@ class MobileUnitSerializer(serializers.ModelSerializer):
         representation = super().to_representation(obj)
         unit_id = getattr(obj, "unit_id", None)
         # If serializing Unit instance or MobileUnit with unit_id.
-        if self.context.get("services_unit_instance", False) or unit_id:
+        if self.context.get("services_unit_instances", False) or unit_id:
             if unit_id:
                 # When serializing the MobileUnit from the retrieve method
                 try:
@@ -135,7 +135,7 @@ class MobileUnitSerializer(serializers.ModelSerializer):
             except Unit.DoesNotExist:
                 return None
         # If serializing Unit object retrieved from the view.
-        elif self.context.get("services_unit_instance", False):
+        elif self.context.get("services_unit_instances", False):
             geometry = obj.location
         else:
             geometry = obj.geometry

--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -44,6 +44,7 @@ class MobileUnitSerializer(serializers.ModelSerializer):
 
     content_types = ContentTypeSerializer(many=True, read_only=True)
     mobile_unit_group = MobileUnitGroupBasicInfoSerializer(many=False, read_only=True)
+    # geometry = serializers.SerializerMethodField(read_only=True)
     geometry_coords = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
@@ -85,10 +86,18 @@ class MobileUnitSerializer(serializers.ModelSerializer):
 
     def to_representation(self, obj):
         representation = super().to_representation(obj)
-        # If mobile_unit has a unit_id we serialize the data from the services_unit table.
-        unit_id = obj.unit_id
-        if unit_id:
-            unit = Unit.objects.get(id=unit_id)
+        unit_id = getattr(obj, "unit_id", None)
+        # If serializing Unit instance or MobileUnit with unit_id.
+        if self.context.get("services_unit_instance", False) or unit_id:
+            if unit_id:
+                # When serializing the MobileUnit from the retrieve method
+                try:
+                    unit = Unit.objects.get(id=unit_id)
+                except Unit.DoesNotExist:
+                    return representation
+            else:
+                # The obj is a Unit instance.
+                unit = obj
             for field in self.fields:
                 # lookup the field name in the service_unit table, as not all field names that contains
                 # similar data has the same name.
@@ -100,21 +109,34 @@ class MobileUnitSerializer(serializers.ModelSerializer):
                 if hasattr(unit, key):
                     # unit.municipality is of type munigeo.models.Municipality and not serializable
                     if key == "municipality":
-                        representation[field] = unit.municipality.id
+                        muni = getattr(unit, key, None)
+                        representation[field] = muni.id if muni else None
                     else:
-                        representation[field] = getattr(unit, key)
+                        representation[field] = getattr(unit, key, None)
                 # Serialize the MobileUnit id, otherwise would serialize the serivce_unit id.
                 if field == "id":
-                    representation["id"] = obj.id
+                    try:
+                        representation["id"] = MobileUnit.objects.get(
+                            unit_id=unit.id
+                        ).id
+                    except MobileUnit.DoesNotExist:
+                        representation["id"] = unit.id
             # The location field must be serialized with its wkt value.
             if unit.location:
                 representation["geometry"] = unit.location.wkt
         return representation
 
     def get_geometry_coords(self, obj):
-        # If stored to Unit table, retrieve geometry from there.
-        if obj.unit_id:
-            geometry = Unit.objects.get(id=obj.unit_id).location
+        unit_id = getattr(obj, "unit_id", None)
+        if unit_id:
+            # If stored to Unit table, retrieve geometry from there.
+            try:
+                geometry = Unit.objects.get(id=unit_id).location
+            except Unit.DoesNotExist:
+                return None
+        # If serializing Unit object retrieved from the view.
+        elif self.context.get("services_unit_instance", False):
+            geometry = obj.location
         else:
             geometry = obj.geometry
         if isinstance(geometry, GEOSGeometry):

--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -44,7 +44,6 @@ class MobileUnitSerializer(serializers.ModelSerializer):
 
     content_types = ContentTypeSerializer(many=True, read_only=True)
     mobile_unit_group = MobileUnitGroupBasicInfoSerializer(many=False, read_only=True)
-    # geometry = serializers.SerializerMethodField(read_only=True)
     geometry_coords = serializers.SerializerMethodField(read_only=True)
 
     class Meta:

--- a/mobility_data/importers/utils.py
+++ b/mobility_data/importers/utils.py
@@ -68,7 +68,7 @@ def fetch_json(url):
 
 
 def delete_mobile_units(name):
-    ContentType.objects.filter(name=name).delete()
+    MobileUnit.objects.filter(content_types__name=name).delete()
 
 
 def create_mobile_unit_as_unit_reference(unit_id, content_type):

--- a/mobility_data/management/commands/import_share_car_parking_places.py
+++ b/mobility_data/management/commands/import_share_car_parking_places.py
@@ -19,4 +19,4 @@ class Command(BaseImportCommand):
 
         objects = get_car_share_parking_place_objects(geojson_file=geojson_file)
         save_to_database(objects)
-        logger.info(f"Imported {len(objects)} char share parking places.")
+        logger.info(f"Imported {len(objects)} car share parking places.")

--- a/mobility_data/tests/conftest.py
+++ b/mobility_data/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry, Point
+from django.utils import timezone
 from munigeo.models import (
     Address,
     AdministrativeDivision,
@@ -10,6 +11,8 @@ from munigeo.models import (
     Street,
 )
 from rest_framework.test import APIClient
+
+from services.models import Service, Unit, UnitServiceDetails
 
 from ..models import ContentType, GroupType, MobileUnit, MobileUnitGroup
 
@@ -48,12 +51,26 @@ def api_client():
 @pytest.fixture
 def content_types():
     content_types = [
-        ContentType.objects.create(name="Test", description="test content type")
+        ContentType.objects.create(
+            id="aa6c2903-d36f-4c61-b828-19084fc7a64b",
+            name="Test",
+            description="test content type",
+        )
     ]
     content_types.append(
-        ContentType.objects.create(name="Test2", description="test content type2")
+        ContentType.objects.create(
+            id="ba6c2903-d36f-4c61-b828-19084fc7a64b",
+            name="Test2",
+            description="test content type2",
+        )
     )
-
+    content_types.append(
+        ContentType.objects.create(
+            id="ca6c2903-d36f-4c61-b828-19084fc7a64b",
+            name="Test unit",
+            description="test content type3",
+        )
+    )
     return content_types
 
 
@@ -79,6 +96,7 @@ def mobile_units(content_types):
     geometry = Point(22.21, 60.3, srid=4326)
     geometry.transform(settings.DEFAULT_SRID)
     mobile_unit = MobileUnit.objects.create(
+        id="aa6c2903-d36f-4c61-b828-19084fc7a64b",
         name="Test mobileunit",
         description="Test description",
         geometry=geometry,
@@ -93,15 +111,42 @@ def mobile_units(content_types):
         "test_bool": True,
     }
     mobile_unit = MobileUnit.objects.create(
+        id="ba6c2903-d36f-4c61-b828-19084fc7a64b",
         name="Test2 mobileunit",
         description="Test2 description",
-        geometry=Point(43.43, 22.22, srid=settings.DEFAULT_SRID),
+        geometry=Point(23.43, 62.22, srid=settings.DEFAULT_SRID),
         extra=extra,
     )
     mobile_unit.content_types.add(content_types[0])
     mobile_unit.content_types.add(content_types[1])
     mobile_units.append(mobile_units)
+    mobile_unit = MobileUnit.objects.create(
+        id="ca6c2903-d36f-4c61-b828-19084fc7a64b", unit_id=1
+    )
+    mobile_unit.content_types.add(content_types[2])
+    mobile_units.append(mobile_units)
     return mobile_units
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def service():
+    return Service.objects.create(id=1, name="test", last_modified_time=timezone.now())
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def unit(service):
+    unit = Unit.objects.create(
+        id=1,
+        name="Test unit",
+        description="desc",
+        last_modified_time=timezone.now(),
+        provider_type=1,
+        location=Point(24.24, 62.22, srid=settings.DEFAULT_SRID),
+    )
+    UnitServiceDetails(unit=unit, service=service).save()
+    return unit
 
 
 @pytest.mark.django_db

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -122,7 +122,7 @@ def test_mobile_unit(api_client, mobile_units, content_types, unit):
 
 
 @pytest.mark.django_db
-def test_mobile_unit_group(api_client, mobile_unit_group, group_type, unit):
+def test_mobile_unit_group(api_client, mobile_unit_group, group_type):
     url = reverse("mobility_data:mobile_unit_groups-list")
     response = api_client.get(url)
     assert response.status_code == 200

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -9,6 +9,7 @@ def test_content_type(api_client, content_types):
     url = reverse("mobility_data:content_types-list")
     response = api_client.get(url)
     assert response.status_code == 200
+    assert len(response.json()["results"]) == len(content_types)
     result = response.json()["results"][0]
     assert result["name"] == "Test"
     assert result["description"] == "test content type"
@@ -25,11 +26,18 @@ def test_group_type(api_client, group_type):
 
 
 @pytest.mark.django_db
-def test_mobile_unit(api_client, mobile_units, content_types):
+def test_mobile_unit(api_client, mobile_units, content_types, unit):
     url = reverse("mobility_data:mobile_units-list")
     response = api_client.get(url)
     assert response.status_code == 200
-    result = response.json()["results"][1]
+    assert len(response.json()["results"]) == len(mobile_units)
+    url = reverse(
+        "mobility_data:mobile_units-detail",
+        args=["aa6c2903-d36f-4c61-b828-19084fc7a64b"],
+    )
+    response = api_client.get(url)
+    assert response.status_code == 200
+    result = response.json()
     assert result["name"] == "Test mobileunit"
     assert result["description"] == "Test description"
     assert result["content_types"][0]["id"] == str(content_types[0].id)
@@ -39,8 +47,14 @@ def test_mobile_unit(api_client, mobile_units, content_types):
     assert result["geometry"] == Point(
         235404.6706163187, 6694437.919005549, srid=settings.DEFAULT_SRID
     )
+    url = reverse(
+        "mobility_data:mobile_units-detail",
+        args=["ba6c2903-d36f-4c61-b828-19084fc7a64b"],
+    )
+    response = api_client.get(url)
+    assert response.status_code == 200
     # Test multiple content types
-    result = response.json()["results"][0]
+    result = response.json()
     assert len(result["content_types"]) == 2
     assert result["content_types"][0]["name"] == "Test"
     assert result["content_types"][1]["name"] == "Test2"
@@ -91,10 +105,24 @@ def test_mobile_unit(api_client, mobile_units, content_types):
     url = reverse("mobility_data:mobile_units-list") + "?bbox=22.1,60.2,2.3,60.4"
     response = api_client.get(url)
     assert len(response.json()["results"]) == 0
+    # Test data serialization from services_unit model
+    url = reverse(
+        "mobility_data:mobile_units-detail",
+        args=["ca6c2903-d36f-4c61-b828-19084fc7a64b"],
+    )
+    response = api_client.get(url)
+    assert response.status_code == 200
+    result = response.json()
+    assert result["name"] == "Test unit"
+    assert result["description"] == "desc"
+    assert result["content_types"][0]["name"] == "Test unit"
+    assert result["geometry"] == "POINT (24.24 62.22)"
+    assert result["geometry_coords"]["lon"] == 24.24
+    assert result["geometry_coords"]["lat"] == 62.22
 
 
 @pytest.mark.django_db
-def test_mobile_unit_group(api_client, mobile_unit_group, group_type):
+def test_mobile_unit_group(api_client, mobile_unit_group, group_type, unit):
     url = reverse("mobility_data:mobile_unit_groups-list")
     response = api_client.get(url)
     assert response.status_code == 200


### PR DESCRIPTION
# Bugfix/mobile units with unit_id not filtered correctly

## Description
FIltering with 'bbox' or with 'extra__'  caused server error with MobileUnits that contained only a unit_id.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### API
1. mobility_data/api/views.py
    * Retrieve and filter services_unit instances if unit_id set
2. mobility_data/api/serializers/mobile_unit.py
    * Serialize services_unit instances

#### Tests
1. mobility_data/tests/conftest.py
    * Add service, unit and mobile_unit with unit_id fixture
2. mobility_data/tests/test_api.py
    * Test serialization from services_unit
#### Importer
1. mobility_data/management/commands/import_share_car_parking_places.py
    * Fix typo