### PR TITLE
Feature/culture route importer refactor

### DIFF
--- a/mobility_data/importers/data/content_types.yml
+++ b/mobility_data/importers/data/content_types.yml
@@ -406,3 +406,15 @@ content_types:
       sv: Hastighetsbegränsningszon
       en: Speed limit zone
   # End of WFS importer content types
+
+  - content_type_name: CultureRouteUnit
+    name:
+      fi: Kultuurikuntoilureitti
+      sv: Kulturväg
+      en: Culture route
+
+  - content_type_name: CultureRouteGeometry
+    name:
+      fi: Kulttuurikuntoilureitin geometria
+      sv: Geometri för kulturväg
+      en: Geometry for culture route

--- a/mobility_data/management/commands/import_culture_routes.py
+++ b/mobility_data/management/commands/import_culture_routes.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
             routes, delete_tables=delete_tables
         )
         logger.info(
-            "Fetchet {} Culture Routes. Saved {} routes and deleted {} obsolete routes."
+            "Fetched {} Culture Routes. Saved {} routes and deleted {} obsolete routes."
             " Saved {} units and deleted {} obsolete units".format(
                 len(routes), routes_saved, routes_deleted, units_saved, units_deleted
             )

--- a/mobility_data/management/commands/import_culture_routes.py
+++ b/mobility_data/management/commands/import_culture_routes.py
@@ -19,12 +19,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         logger.info("Importing culture routes...")
         routes = get_routes()
-        delete_tables = False
-        if options["delete"]:
-            delete_tables = True
-        num_saved = save_to_database(routes, delete_tables=delete_tables)
+        delete_tables = options.get("delete", False)
+        routes_saved, routes_deleted, units_saved, units_deleted = save_to_database(
+            routes, delete_tables=delete_tables
+        )
         logger.info(
-            "Fetched {} Culture Routes and saved {} new Culture Routes to database.".format(
-                len(routes), num_saved
+            "Fetchet {} Culture Routes. Saved {} routes and deleted {} obsolete routes."
+            " Saved {} units and deleted {} obsolete units".format(
+                len(routes), routes_saved, routes_deleted, units_saved, units_deleted
             )
         )


### PR DESCRIPTION
# Culture route importer refactoring


-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. mobility_data/importers/culture_routes.py
   * Create content types with generic function and YAML config. Delete obsolete routes and units during saving.
2. mobility_data/importers/data/content_types.yml
    * Add content types for CultureRouteUnit and CultureRouteGeometry.
3. mobility_data/management/commands/import_culture_routes.py
    * Display number of saved and deleted routes and units