### PR TITLE
Feature/mobileunit view refactor and add params

### DIFF
--- a/mobility_data/api/serializers/mobile_unit.py
+++ b/mobility_data/api/serializers/mobile_unit.py
@@ -84,6 +84,16 @@ class MobileUnitSerializer(serializers.ModelSerializer):
         "unit_id": "id",
     }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        context = kwargs.get("context", {})
+        if "only" in context:
+            self.keep_fields = set(context["only"] + ["id"])
+            for field_name in list(self.fields.keys()):
+                if field_name in self.keep_fields:
+                    continue
+                del self.fields[field_name]
+
     def to_representation(self, obj):
         representation = super().to_representation(obj)
         unit_id = getattr(obj, "unit_id", None)
@@ -122,7 +132,7 @@ class MobileUnitSerializer(serializers.ModelSerializer):
                 if field == "unit_id":
                     representation["unit_id"] = mobile_unit.unit_id
             # The location field must be serialized with its wkt value.
-            if unit.location:
+            if unit.location and "geometry" in representation:
                 representation["geometry"] = unit.location.wkt
         return representation
 

--- a/mobility_data/api/views.py
+++ b/mobility_data/api/views.py
@@ -144,6 +144,10 @@ class MobileUnitViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
+        only = self.request.query_params.get("only", "")
+        if only:
+            context["only"] = [x.strip() for x in only.split(",") if x]
+
         context["srid"], context["latlon"] = get_srid_and_latlon(
             self.request.query_params
         )

--- a/mobility_data/api/views.py
+++ b/mobility_data/api/views.py
@@ -224,12 +224,13 @@ class MobileUnitViewSet(viewsets.ReadOnlyModelViewSet):
     def list(self, request):
         queryset = self.get_queryset()
         page = self.paginate_queryset(queryset)
-        logger.debug(connection.queries)
-        queries_time = sum([float(s["time"]) for s in connection.queries])
-        logger.debug(
-            f"Search queries total execution time: {queries_time} Num queries: {len(connection.queries)}"
-        )
-        reset_queries()
+        if logger.level <= logging.DEBUG:
+            logger.debug(connection.queries)
+            queries_time = sum([float(s["time"]) for s in connection.queries])
+            logger.debug(
+                f"MobileUnit list queries total execution time: {queries_time} Num queries: {len(connection.queries)}"
+            )
+            reset_queries()
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 

--- a/mobility_data/specification.swagger2.0.yaml
+++ b/mobility_data/specification.swagger2.0.yaml
@@ -133,6 +133,7 @@ paths:
         - $ref: "#/components/parameters/srid_param"
         - $ref: "#/components/parameters/latlon_param"
         - $ref: "#/components/parameters/type_name_param"
+        - $ref: "#/components/parameters/type_names_param"
         - $ref: "#/components/parameters/extra_param"
         - $ref: "#/components/parameters/bbox_param"
         - $ref: "#/components/parameters/bbox_srid_param"
@@ -324,3 +325,18 @@ components:
         type: array
         items:
           type: string
+      example: name,geometry
+
+    type_names_param:
+      name: type_names
+      in: query
+       style: form
+      explode: false
+      description: Return MobileUnits from multiple content types. Separate field names by
+        commas. Note, Filtering MobileUnits with ContentTypes containing MobileUnits and MobileUnits 
+        that contains references to services_unit table is not possible.
+      schema:
+        type: array
+        items:
+          type: string
+      example: PublicToilet,HikingTrail

--- a/mobility_data/specification.swagger2.0.yaml
+++ b/mobility_data/specification.swagger2.0.yaml
@@ -136,6 +136,7 @@ paths:
         - $ref: "#/components/parameters/extra_param"
         - $ref: "#/components/parameters/bbox_param"
         - $ref: "#/components/parameters/bbox_srid_param"
+        - $ref: "#/components/parameters/only_param"
 
       responses:
         200:
@@ -305,9 +306,21 @@ components:
     
     bbox_srid_param:
       name: bbox_srid
-        in: query
-        description: An SRID coordinate reference system identifier which specifies the
-          coordinate system used in the bbox parameter. 
-        schema:
-          type: integer
-        example: 3046
+      in: query
+      description: An SRID coordinate reference system identifier which specifies the
+        coordinate system used in the bbox parameter. 
+      schema:
+        type: integer
+      example: 3046
+    
+    only_param:
+      name: only
+      in: query
+       style: form
+      explode: false
+      description: Restrict the field returned in the results. Separate field names by
+        commas.
+      schema:
+        type: array
+        items:
+          type: string

--- a/mobility_data/tests/conftest.py
+++ b/mobility_data/tests/conftest.py
@@ -50,31 +50,25 @@ def api_client():
 @pytest.mark.django_db
 @pytest.fixture
 def content_types():
-    content_types = [
-        ContentType.objects.create(
-            id="aa6c2903-d36f-4c61-b828-19084fc7a64b",
-            type_name="Test",
-            name_fi="fi",
-            name_sv="sv",
-            name_en="en",
-            description="test content type",
-        )
-    ]
-    content_types.append(
-        ContentType.objects.create(
-            id="ba6c2903-d36f-4c61-b828-19084fc7a64b",
-            type_name="Test2",
-            description="test content type2",
-        )
+    ContentType.objects.create(
+        id="aa6c2903-d36f-4c61-b828-19084fc7a64b",
+        type_name="Test",
+        name_fi="fi",
+        name_sv="sv",
+        name_en="en",
+        description="test content type",
     )
-    content_types.append(
-        ContentType.objects.create(
-            id="ca6c2903-d36f-4c61-b828-19084fc7a64b",
-            type_name="Test unit",
-            description="test content type3",
-        )
+    ContentType.objects.create(
+        id="ba6c2903-d36f-4c61-b828-19084fc7a64b",
+        type_name="Test2",
+        description="test content type2",
     )
-    return content_types
+    ContentType.objects.create(
+        id="ca6c2903-d36f-4c61-b828-19084fc7a64b",
+        type_name="TestUnit",
+        description="test content type3",
+    )
+    return ContentType.objects.all()
 
 
 @pytest.mark.django_db
@@ -89,7 +83,6 @@ def group_type():
 @pytest.mark.django_db
 @pytest.fixture
 def mobile_units(content_types):
-    mobile_units = []
     extra = {
         "test_int": 4242,
         "test_float": 42.42,
@@ -105,8 +98,7 @@ def mobile_units(content_types):
         geometry=geometry,
         extra=extra,
     )
-    mobile_unit.content_types.add(content_types[0])
-    mobile_units.append(mobile_units)
+    mobile_unit.content_types.add(ContentType.objects.get(type_name="Test"))
     extra = {
         "test_int": 14,
         "test_float": 2.4,
@@ -120,15 +112,13 @@ def mobile_units(content_types):
         geometry=Point(23.43, 62.22, srid=settings.DEFAULT_SRID),
         extra=extra,
     )
-    mobile_unit.content_types.add(content_types[0])
-    mobile_unit.content_types.add(content_types[1])
-    mobile_units.append(mobile_units)
+    mobile_unit.content_types.add(ContentType.objects.get(type_name="Test"))
+    mobile_unit.content_types.add(ContentType.objects.get(type_name="Test2"))
     mobile_unit = MobileUnit.objects.create(
         id="ca6c2903-d36f-4c61-b828-19084fc7a64b", unit_id=1
     )
-    mobile_unit.content_types.add(content_types[2])
-    mobile_units.append(mobile_units)
-    return mobile_units
+    mobile_unit.content_types.add(ContentType.objects.get(type_name="TestUnit"))
+    return MobileUnit.objects.all()
 
 
 @pytest.mark.django_db
@@ -166,11 +156,10 @@ def mobile_unit_group(group_type):
 @pytest.mark.django_db
 @pytest.fixture
 def municipalities():
-    munis = []
-    munis.append(Municipality.objects.create(id="turku", name="Turku"))
-    munis.append(Municipality.objects.create(id="lieto", name="Lieto"))
-    munis.append(Municipality.objects.create(id="raisio", name="Raisio"))
-    return munis
+    Municipality.objects.create(id="turku", name="Turku")
+    Municipality.objects.create(id="lieto", name="Lieto")
+    Municipality.objects.create(id="raisio", name="Raisio")
+    return Municipality.objects.all()
 
 
 @pytest.mark.django_db
@@ -204,66 +193,57 @@ def administrative_division_geometry(administrative_division):
 @pytest.mark.django_db
 @pytest.fixture
 def streets():
-    streets = []
-    street = Street.objects.create(
+    Street.objects.create(
         name="Test Street",
         name_fi="Test Street",
         name_sv="Test StreetSV",
         municipality_id="turku",
     )
-    streets.append(street)
-    street = Street.objects.create(
+    Street.objects.create(
         name="Linnanpuisto",
         name_fi="Linnanpuisto",
         name_sv="Slottsparken",
         municipality_id="turku",
     )
-    streets.append(street)
-    street = Street.objects.create(
+    Street.objects.create(
         name="Kristiinankatu",
         name_fi="Kristiinankatu",
         name_sv="Kristinegatan",
         municipality_id="turku",
     )
-    streets.append(street)
-    street = Street.objects.create(
+    Street.objects.create(
         name="Pitkäpellonkatu",
         name_fi="Pitkäpellonkatu",
         name_sv="Långåkersgatan",
         municipality_id="turku",
     )
-    streets.append(street)
-    street = Street.objects.create(
+    Street.objects.create(
         name="Kupittaankatu",
         name_fi="Kupittaankatu",
         name_sv="Kuppisgatan",
         municipality_id="turku",
     )
-    streets.append(street)
-    street = Street.objects.create(
+    Street.objects.create(
         name="Yliopistonkatu",
         name_fi="Yliopistonkatu",
         name_sv="Universitetsgatan",
         municipality_id="turku",
     )
-    streets.append(street)
-    street = Street.objects.create(
+    Street.objects.create(
         name="Ratapihankatu",
         name_fi="Ratapihankatu",
         name_sv="Bangårdsgatan",
         municipality_id="turku",
     )
-    streets.append(street)
-    return streets
+    return Street.objects.all()
 
 
 @pytest.mark.django_db
 @pytest.fixture
 def address(streets, municipalities):
-    turku_muni = municipalities[0]
-    addresses = []
+    turku_muni = Municipality.objects.get(id="turku")
     location = Point(22.244, 60.4, srid=4326)
-    address = Address.objects.create(
+    Address.objects.create(
         municipality_id=turku_muni.id,
         id=100,
         location=location,
@@ -272,9 +252,8 @@ def address(streets, municipalities):
         full_name_fi="Test Street 42",
         full_name_sv="Test StreetSV 42",
     )
-    addresses.append(address)
     location = Point(22.227168, 60.4350612, srid=4326)
-    address = Address.objects.create(
+    Address.objects.create(
         municipality_id=turku_muni.id,
         id=101,
         location=location,
@@ -282,9 +261,8 @@ def address(streets, municipalities):
         full_name_fi="Linnanpuisto",
         full_name_sv="Slottsparken",
     )
-    addresses.append(address)
     location = Point(22.264457, 60.448905, srid=4326)
-    address = Address.objects.create(
+    Address.objects.create(
         municipality_id=turku_muni.id,
         id=102,
         location=location,
@@ -293,9 +271,8 @@ def address(streets, municipalities):
         full_name_fi="Kristiinankatu 4",
         full_name_sv="Kristinegata 4",
     )
-    addresses.append(address)
     location = Point(22.2383, 60.411726, srid=4326)
-    address = Address.objects.create(
+    Address.objects.create(
         municipality_id=turku_muni.id,
         id=103,
         location=location,
@@ -304,9 +281,8 @@ def address(streets, municipalities):
         full_name_fi="Pitkäpellonkatu 7",
         full_name_sv="Långåkersgatan 7",
     )
-    addresses.append(address)
     location = Point(22.2871092678621, 60.44677715747775, srid=4326)
-    address = Address.objects.create(
+    Address.objects.create(
         municipality_id=turku_muni.id,
         id=104,
         location=location,
@@ -315,9 +291,8 @@ def address(streets, municipalities):
         full_name_fi="Kupittaankatu 8",
         full_name_sv="Kuppisgatan 8",
     )
-    addresses.append(address)
     location = Point(22.26097246971352, 60.45055294118857, srid=4326)
-    address = Address.objects.create(
+    Address.objects.create(
         municipality_id=turku_muni.id,
         id=105,
         location=location,
@@ -326,9 +301,8 @@ def address(streets, municipalities):
         full_name_fi="Yliopistonkatu 29",
         full_name_sv="Universitetsgatan 29",
     )
-    addresses.append(address)
     location = Point(22.247047171564706, 60.45159033848499, srid=4326)
-    address = Address.objects.create(
+    Address.objects.create(
         municipality_id=turku_muni.id,
         id=106,
         location=location,
@@ -337,4 +311,4 @@ def address(streets, municipalities):
         full_name_fi="Ratapihankatu 53",
         full_name_sv="Bangårdsgatan 53",
     )
-    addresses.append(address)
+    return Address.objects.all()

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -128,8 +128,6 @@ def test_mobile_unit(api_client, mobile_units, content_types, unit):
     assert len(response.json()["results"][0]) == 2
     assert len(response.json()["results"][1]) == 2
 
-    breakpoint()
-
 
 @pytest.mark.django_db
 def test_mobile_unit_group(api_client, mobile_unit_group, group_type):

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -118,7 +118,7 @@ def test_mobile_unit(api_client, mobile_units, content_types, unit):
     result = response.json()
     assert result["name"] == "Test unit"
     assert result["description"] == "desc"
-    assert result["content_types"][0]["type_name"] == "Test unit"
+    assert result["content_types"][0]["type_name"] == "TestUnit"
     assert result["geometry"] == "POINT (24.24 62.22)"
     assert result["geometry_coords"]["lon"] == 24.24
     assert result["geometry_coords"]["lat"] == 62.22
@@ -128,6 +128,10 @@ def test_mobile_unit(api_client, mobile_units, content_types, unit):
     # 'id' is always serialized, so the length will be 3
     assert len(response.json()["results"][0]) == 3
     assert len(response.json()["results"][1]) == 3
+    # Test retrieving multiple content types
+    url = reverse("mobility_data:mobile_units-list") + "?type_names=Test,Test2"
+    response = api_client.get(url)
+    assert len(response.json()["results"]) == 2
 
 
 @pytest.mark.django_db

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -105,7 +105,7 @@ def test_mobile_unit(api_client, mobile_units, content_types, unit):
     response = api_client.get(url)
     assert len(response.json()["results"]) == 1
     # Test bbox where no mobile units are inside.
-    url = reverse("mobility_data:mobile_units-list") + "?bbox=22.1,60.2,2.3,60.4"
+    url = reverse("mobility_data:mobile_units-list") + "?bbox=22.3,61.4,23,62.4"
     response = api_client.get(url)
     assert len(response.json()["results"]) == 0
     # Test data serialization from services_unit model

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -123,10 +123,11 @@ def test_mobile_unit(api_client, mobile_units, content_types, unit):
     assert result["geometry_coords"]["lon"] == 24.24
     assert result["geometry_coords"]["lat"] == 62.22
     # Test only param
-    url = reverse("mobility_data:mobile_units-list") + "?only=id,name"
+    url = reverse("mobility_data:mobile_units-list") + "?only=name,geometry"
     response = api_client.get(url)
-    assert len(response.json()["results"][0]) == 2
-    assert len(response.json()["results"][1]) == 2
+    # 'id' is always serialized, so the length will be 3
+    assert len(response.json()["results"][0]) == 3
+    assert len(response.json()["results"][1]) == 3
 
 
 @pytest.mark.django_db

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -122,6 +122,13 @@ def test_mobile_unit(api_client, mobile_units, content_types, unit):
     assert result["geometry"] == "POINT (24.24 62.22)"
     assert result["geometry_coords"]["lon"] == 24.24
     assert result["geometry_coords"]["lat"] == 62.22
+    # Test only param
+    url = reverse("mobility_data:mobile_units-list") + "?only=id,name"
+    response = api_client.get(url)
+    assert len(response.json()["results"][0]) == 2
+    assert len(response.json()["results"][1]) == 2
+
+    breakpoint()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# Refactor mobileunit API view, add 'only' and 'type_names' parameters



-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. mobility_data/api/serializers/mobile_unit.py
    * If only in context serialize only those fields, 
2. mobility_data/api/views.py
    * Refactor(add get_queryset and get_serializer_context functions), add only and type_names params.
3. mobility_data/specification.swagger2.0.yaml
    * Add info about 'only' and 'type_names' param
4. mobility_data/tests/conftest.py
    * Refactor
5. mobility_data/tests/test_api.py
    * Add tests for 'only' and 'type_names' params.