### PR TITLE
division import fails due to execution of queries in the atomic block

### DIFF
--- a/smbackend_turku/management/commands/turku_services_import.py
+++ b/smbackend_turku/management/commands/turku_services_import.py
@@ -142,7 +142,6 @@ class Command(BaseCommand):
     def import_enriched_addresses(self):
         return import_enriched_addresses(logger=self.logger)
 
-    @db.transaction.atomic
     def import_divisions(self):
         return import_divisions(logger=self.logger)
 


### PR DESCRIPTION
# Division import fails due to execution of queries in the atomic block

-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed
 1.  smbackend_turku/management/commands/turku_services_import.py
     * Remove atomic transaction from importing divisions