### PR TITLE
Feature/fix eco counter warnings

### DIFF
--- a/eco_counter/constants.py
+++ b/eco_counter/constants.py
@@ -127,7 +127,7 @@ TELRAAM_COUNTER_CAMERAS = {
 retry_strategy = Retry(
     total=10,
     status_forcelist=[429],
-    method_whitelist=["GET", "POST"],
+    allowed_methods=["GET", "POST"],
     backoff_factor=30,  # 30, 60, 120 , 240, ..seconds
 )
 adapter = HTTPAdapter(max_retries=retry_strategy)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,7 @@
 DJANGO_SETTINGS_MODULE = smbackend.settings
 addopts =  -m "not test_import_counter_data" 
 markers =
-    to test counter importers run '-m test_import_counter_data'
+    test_import_counter_data: mark a test for (eco) counter data, to test counter importers run 'pytest -m test_import_counter_data'
+   
+
+  


### PR DESCRIPTION
# fix eco counter warnings
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. eco_counter/constants.py 
     * Change deprecated 'method_whitelist' -> 'allowed_methods'
2.  pytest.ini
     * Add missing test_import_counter_data marker

