### PR TITLE
Feature/eco counter filter station by data type

### DIFF
--- a/eco_counter/api/views.py
+++ b/eco_counter/api/views.py
@@ -65,6 +65,21 @@ class StationViewSet(viewsets.ReadOnlyModelViewSet):
                 raise ParseError(
                     "Valid 'counter_type' choices are: 'EC', 'TC', 'TR' or 'LC'."
                 )
+        if "data_type" in filters:
+            data_type = filters["data_type"].lower()
+            data_types = ["a", "j", "b", "p"]
+            if data_type not in data_types:
+                raise ParseError(
+                    f"Valid 'data_type' choices are: {', '.join(data_types)}"
+                )
+            ids = []
+            data_type = data_type + "t"
+            for station in Station.objects.all():
+                filter = {"station": station, f"value_{data_type}__gt": 0}
+                if YearData.objects.filter(**filter).count() > 0:
+                    ids.append(station.id)
+            queryset = Station.objects.filter(id__in=ids)
+
         page = self.paginate_queryset(queryset)
         serializer = StationSerializer(page, many=True)
         return self.get_paginated_response(serializer.data)

--- a/eco_counter/specification.swagger2.0.yaml
+++ b/eco_counter/specification.swagger2.0.yaml
@@ -252,7 +252,7 @@ paths:
         name: counter_type
         type: string
       - in: query
-        description: "The data type of the counter: A(car), B(bus), J(pedestrian) or P(bicycle). Returns stations containing data of the specifiec type."
+        description: "The data type of the counter: A(car), B(bus), J(pedestrian) or P(bicycle). Returns stations containing data of the specified type."
         name: data_type
         type: string
       responses:

--- a/eco_counter/specification.swagger2.0.yaml
+++ b/eco_counter/specification.swagger2.0.yaml
@@ -251,6 +251,10 @@ paths:
         description: "The type of the counter EC(Eco Counter), TC(Traffic Counter), LC(LAM Counter), TR(Telraam Counter)"
         name: counter_type
         type: string
+      - in: query
+        description: "The data type of the counter: A(car), B(bus), J(pedestrian) or P(bicycle). Returns stations containing data of the specifiec type."
+        name: data_type
+        type: string
       responses:
         200:
           description: "List of stations."

--- a/eco_counter/tests/test_api.py
+++ b/eco_counter/tests/test_api.py
@@ -271,3 +271,10 @@ def test__station(api_client, stations, year_datas):
     assert response.status_code == 200
     assert response.json()["results"][0]["name"] == TEST_EC_STATION_NAME
     assert response.json()["results"][0]["sensor_types"] == ["at"]
+    # Test retrieving station by data type
+    url = reverse("eco_counter:stations-list") + "?data_type=a"
+    response = api_client.get(url)
+    assert response.json()["count"] == 1
+    url = reverse("eco_counter:stations-list") + "?data_type=p"
+    response = api_client.get(url)
+    assert response.json()["count"] == 0


### PR DESCRIPTION
# Eco-counter filter station by data type

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. eco_counter/api/views.py
     * Add data_type filter param to Station list view
2. eco_counter/specification.swagger2.0.yaml
    * Add data_type param info
3. eco_counter/tests/test_api.py
    * Test data_type param