### PR TITLE
Feature/fix GitHub actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,9 +19,9 @@ jobs:
       LAM_COUNTER_API_BASE_URL: https://tie.digitraffic.fi/api/tms/v1/history
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.10.0
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.10.0
     - name: Install required Ubuntu packages
@@ -50,7 +50,7 @@ jobs:
         pip install coverage
         coverage report -m
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v2  
+      uses: codecov/codecov-action@v3  
     # Majority of the tests require database
     services:
       # Label used to access the service container

--- a/requirements.txt
+++ b/requirements.txt
@@ -197,7 +197,7 @@ pytz==2021.3
     #   celery
     #   django-timezone-field
     #   pandas
-pyyaml==5.4.1
+pyyaml==5.3.1
     # via
     #   django-munigeo
     #   drf-spectacular


### PR DESCRIPTION
# Fix broken github actions

## Description
Updates action v2 to v3 as node12 is no longer supported. 
Downgrades pyyaml 5.3.1, see: https://github.com/yaml/pyyaml/issues/724

#### Trello #439
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. .github/workflows/run-tests.yml
     * Change v2 to v3 
2. requirements.txt
    * Change pyyaml version to 5.3.1