### PR TITLE
bugfix/major district swedish names not imported

### DIFF
--- a/smbackend_turku/importers/data/divisions_config.yml
+++ b/smbackend_turku/importers/data/divisions_config.yml
@@ -12,7 +12,7 @@ divisions:
     fields:
         name:
             fi: Tunnus_FIN
-            sv: Tunnus_FIN
+            sv: Tunnus_SVE
         origin_id: Tunnus_FIN
         ocd_id: Tunnus_FIN
 


### PR DESCRIPTION
# Fix Swedish name source field for major district

#### Trello #493


-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed
 1. smbackend_turku/importers/data/divisions_config.yml
     * Fix Swedish name source field for major district