### PR TITLE
Bugfix/environment data incremental import creates duplicate weekdata measurements

### DIFF
--- a/environment_data/management/commands/import_environment_data.py
+++ b/environment_data/management/commands/import_environment_data.py
@@ -168,16 +168,17 @@ def save_weeks(df, stations):
             if week.years.count() == 0:
                 week.years.add(year)
             values = get_measurements(data_frame, station.name)
-            week_data, _ = WeekData.objects.get_or_create(station=station, week=week)
+            week_data, created = WeekData.objects.get_or_create(
+                station=station, week=week
+            )
+            if not created:
+                week_data.measurements.all().delete()
             for item in values.items():
                 parameter = get_parameter(item[0])
-                if not week_data.measurements.filter(
+                measurement = Measurement.objects.create(
                     value=item[1], parameter=parameter
-                ):
-                    measurement = Measurement.objects.create(
-                        value=item[1], parameter=parameter
-                    )
-                    week_data.measurements.add(measurement)
+                )
+                week_data.measurements.add(measurement)
 
 
 def save_days(df, stations):

--- a/environment_data/tests/test_importer.py
+++ b/environment_data/tests/test_importer.py
@@ -96,19 +96,15 @@ def test_import_week_data_measurements():
     options = {"initial_import": False}
     assert WeekData.objects.first().measurements.count() == Parameter.objects.count()
     assert WeekData.objects.count() == Parameter.objects.count()
-
-    # Run incremental importer three times with different min_value to ensure no duplicate measurements are created
-    for c in range(3):
-        clear_cache()
-        df = get_test_dataframe(
-            columns, start_time, end_time, min_value=2 - c * 1, max_value=4
-        )
-        save_parameter_types(df, data_type, options["initial_import"])
-        save_measurements(df, data_type, options["initial_import"])
-        assert WeekData.objects.count() == Parameter.objects.count()
-        assert (
-            WeekData.objects.first().measurements.count() == Parameter.objects.count()
-        )
+    assert WeekData.objects.first().measurements.first().value == 3.0
+    # Run incremental importer with different min_value to ensure no duplicate measurements are created
+    clear_cache()
+    df = get_test_dataframe(columns, start_time, end_time, min_value=1, max_value=4)
+    save_parameter_types(df, data_type, options["initial_import"])
+    save_measurements(df, data_type, options["initial_import"])
+    assert WeekData.objects.count() == Parameter.objects.count()
+    assert WeekData.objects.first().measurements.count() == Parameter.objects.count()
+    assert WeekData.objects.first().measurements.first().value == 2.5
 
 
 @pytest.mark.django_db

--- a/environment_data/tests/test_importer.py
+++ b/environment_data/tests/test_importer.py
@@ -69,6 +69,49 @@ def get_test_dataframe(
 
 
 @pytest.mark.django_db
+def test_import_week_data_measurements():
+    from environment_data.management.commands.import_environment_data import (
+        save_measurements,
+        save_parameter_types,
+        save_stations,
+    )
+
+    data_type = AIR_QUALITY
+    options = {"initial_import": True}
+    ImportState.objects.create(
+        data_type=data_type, year_number=aq_constants.START_YEAR, month_number=1
+    )
+    clear_cache()
+    stations = get_stations()
+    save_stations(stations, data_type, options["initial_import"])
+    start_time = dateutil.parser.parse("2020-01-01T00:00:00Z")
+    end_time = dateutil.parser.parse("2020-01-17T23:45:00Z")
+    columns = []
+    for station_name in STATION_NAMES:
+        for parameter in aq_constants.OBSERVABLE_PARAMETERS:
+            columns.append(f"{station_name} {parameter}")
+    df = get_test_dataframe(columns, start_time, end_time)
+    save_parameter_types(df, data_type, options["initial_import"])
+    save_measurements(df, data_type, options["initial_import"])
+    options = {"initial_import": False}
+    assert WeekData.objects.first().measurements.count() == Parameter.objects.count()
+    assert WeekData.objects.count() == Parameter.objects.count()
+
+    # Run incremental importer three times with different min_value to ensure no duplicate measurements are created
+    for c in range(3):
+        clear_cache()
+        df = get_test_dataframe(
+            columns, start_time, end_time, min_value=2 - c * 1, max_value=4
+        )
+        save_parameter_types(df, data_type, options["initial_import"])
+        save_measurements(df, data_type, options["initial_import"])
+        assert WeekData.objects.count() == Parameter.objects.count()
+        assert (
+            WeekData.objects.first().measurements.count() == Parameter.objects.count()
+        )
+
+
+@pytest.mark.django_db
 def test_importer():
     from environment_data.management.commands.import_environment_data import (
         save_measurements,
@@ -252,7 +295,6 @@ def test_importer():
     import_state = ImportState.objects.get(data_type=data_type)
     assert import_state.year_number == 2022
     assert import_state.month_number == 1
-
     # Test initial import
     clear_cache()
     options = {"initial_import": True}


### PR DESCRIPTION
# Bug fixenvironment data incremental import creates duplicate weekdata measurements


### Trello #518

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. environment_data/management/commands/import_environment_data.py
     * Fix bug, duplicate measurements created for week data
 2. environment_data/tests/test_importer.py
     * Test week data measurements