### PR TITLE
Feature/import school and kindergarten accessibility areas

### DIFF
--- a/mobility_data/README.md
+++ b/mobility_data/README.md
@@ -188,6 +188,11 @@ Imports the outdoor gym devices from the services.unit model. i.e., sets referen
 ./manage.py import_parking_machines
 ```
 
+### School and kindergarten accessibility areas
+```
+./manage.py import_wfs SchoolAndKindergartenAccessibilityArea
+```
+
 ## Deletion
 To delete mobile units for a content type.
 ```

--- a/mobility_data/importers/data/content_types.yml
+++ b/mobility_data/importers/data/content_types.yml
@@ -59,7 +59,7 @@ content_types:
       sv: Lastningsplats
       en: Loading place
 
-  # Content types from lounaistieto shapefiles importer
+  # Content types imported from lounaistieto shapefile importer
   - content_type_name: BusStopSouthwestFinland
     name:
       fi: Bussipysäkki
@@ -138,6 +138,7 @@ content_types:
       en: Recreational routes in Southwest Finland
   # End of lounaistieto shapefile importer content types
   
+  # Content types importer from opaskarta.turku.fi
   - content_type_name: GuestMarina
     name:
       fi: Vierasvenesatama
@@ -405,7 +406,14 @@ content_types:
       fi: Nopeusrajoitusalue
       sv: Hastighetsbegränsningszon
       en: Speed limit zone
-  # End of WFS importer content types
+  
+  - content_type_name: SchoolAndKindergartenAccessibilityArea
+    name:
+      fi: Koulu ja päiväkoti saavutettavuusalue
+      sv: Tillgänglighetsområde för skola och daghem
+      en: School and kindergarten accessibility area
+
+  # End of content types importer from opaskarta.turku.fi
 
   - content_type_name: Underpass
     name:

--- a/mobility_data/importers/data/wfs_importer_config.yml
+++ b/mobility_data/importers/data/wfs_importer_config.yml
@@ -514,3 +514,17 @@ features:
       speed_limit:
         wfs_field: rajoitus
         wfs_type: int
+
+  - content_type_name: SchoolAndKindergartenAccessibilityArea
+    content_type_description: Accessibility area of schools and kindergartens
+    wfs_layer: GIS:Koulujen_Paivakotien_saavutettavuus_2023
+    fields:
+      name:
+        fi: Kohde
+    extra_fields:
+      Minuutit:
+        wfs_field: Minuutit
+        wfs_type: int
+      Kulkumuoto:
+        wfs_field: Kulkumuoto
+

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -106,6 +106,13 @@ def import_paavonpolkus(name="import_paavonpolkus"):
 
 
 @shared_task_email
+def import_school_and_kindergarten_accessibility_areas(
+    name="import_import_school_and_kindergarten_accessibility_areas",
+):
+    management.call_command("import_wfs", "SchoolAndKindergartenAccessibilityArea")
+
+
+@shared_task_email
 def delete_mobility_data(args=None, name="delete_mobility_data"):
     management.call_command("delete_mobility_data", args)
 


### PR DESCRIPTION
# Import school and kindergarten accessibility areas

### Trello #539

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
 1. mobility_data/README.md
     *  Add info about school and kindergarten accessibility areas
2. mobility_data/importers/data/content_types.yml
    * Add content type name for school and kindergarten accessibility areas
3. mobility_data/importers/data/wfs_importer_config.yml
    * Add config for school and kindergarten accessibility areas
4. mobility_data/tasks.py
    * Add task to import school and kindergarten accessibility areas