### PR TITLE
Feature/environment data stations add parameters in use to database

### DIFF
--- a/environment_data/api/serializers.py
+++ b/environment_data/api/serializers.py
@@ -34,14 +34,14 @@ class StationSerializer(serializers.ModelSerializer):
 
     def get_parameters_in_use(self, obj):
         res = {}
-        for param in obj.parameters.all():
-            qs = YearData.objects.filter(
-                station=obj, measurements__parameter=param, measurements__value__gte=0
-            )
-            if qs.count():
-                res[param.name] = True
+        available_parameters_qs = Parameter.objects.filter(data_type=obj.data_type)
+
+        for available_parameter in available_parameters_qs:
+            name = available_parameter.name
+            if obj.parameters.filter(name=name).exists():
+                res[name] = True
             else:
-                res[param.name] = False
+                res[name] = False
         return res
 
     def get_data_type_verbose(self, obj):

--- a/environment_data/api/views.py
+++ b/environment_data/api/views.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status, viewsets
 from rest_framework.response import Response
@@ -41,6 +43,7 @@ class StationViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Station.objects.all()
     serializer_class = StationSerializer
 
+    @method_decorator(cache_page(60 * 60))
     def list(self, request, *args, **kwargs):
         queryset = self.queryset
         filters = self.request.query_params

--- a/environment_data/management/commands/air_quality_utils.py
+++ b/environment_data/management/commands/air_quality_utils.py
@@ -33,7 +33,6 @@ def get_dataframe(stations, from_year=START_YEAR, from_month=1, initial_import=F
                 else:
                     params["startTime"] = f"{start_date_time.year}-01-01T00:00Z"
                 if start_date_time.year == current_date_time.year:
-
                     params["endTime"] = current_date_time.strftime(TIME_FORMAT)
                 else:
                     params["endTime"] = f"{start_date_time.year}-12-31T23:59Z"

--- a/environment_data/management/commands/import_environment_data.py
+++ b/environment_data/management/commands/import_environment_data.py
@@ -403,7 +403,23 @@ def save_parameter_types(df, data_type, initial_import=False):
                         "data_type": data_type,
                     },
                 )
+
+
+def save_station_parameters(data_type):
+    # Add parameters that have data to the station
+    for station in Station.objects.filter(data_type=data_type):
+        for parameter in Parameter.objects.filter(data_type=data_type):
+            if (
+                YearData.objects.filter(
+                    station=station,
+                    measurements__parameter=parameter,
+                    measurements__value__gte=0,
+                ).count()
+                > 0
+            ):
                 station.parameters.add(parameter)
+            else:
+                station.parameters.remove(parameter)
 
 
 def save_stations(stations, data_type, initial_import_stations=False):
@@ -529,6 +545,7 @@ class Command(BaseCommand):
             )
             save_parameter_types(df, data_type, initial_import)
             save_measurements(df, data_type, initial_import)
+            save_station_parameters(data_type)
             logger.info(
                 f"Imported {DATA_TYPES_FULL_NAME[data_type]} observations until:{str(df.index[-1])}"
             )

--- a/environment_data/migrations/0001_initial.py
+++ b/environment_data/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/environment_data/tests/conftest.py
+++ b/environment_data/tests/conftest.py
@@ -57,6 +57,8 @@ def measurements(parameters):
 def parameters():
     Parameter.objects.create(id=1, name="AQINDEX_PT1H_avg")
     Parameter.objects.create(id=2, name="NO2_PT1H_avg")
+    Parameter.objects.create(id=3, name="WS_PT1H_avg")
+
     return Parameter.objects.all()
 
 

--- a/environment_data/tests/test_api.py
+++ b/environment_data/tests/test_api.py
@@ -20,7 +20,8 @@ def test_station(api_client, stations, year_datas):
     assert result["data_type_verbose"] == DATA_TYPES_FULL_NAME[AIR_QUALITY]
     assert result["name"] == "Test"
     assert result["parameters_in_use"]["AQINDEX_PT1H_avg"] is True
-    assert result["parameters_in_use"]["NO2_PT1H_avg"] is False
+    assert result["parameters_in_use"]["NO2_PT1H_avg"] is True
+    assert result["parameters_in_use"]["WS_PT1H_avg"] is False
 
 
 @pytest.mark.django_db

--- a/environment_data/tests/test_importer.py
+++ b/environment_data/tests/test_importer.py
@@ -112,6 +112,7 @@ def test_importer():
     from environment_data.management.commands.import_environment_data import (
         save_measurements,
         save_parameter_types,
+        save_station_parameters,
         save_stations,
     )
 
@@ -145,6 +146,10 @@ def test_importer():
         is True
     )
     save_measurements(df, data_type, options["initial_import"])
+    save_station_parameters(data_type)
+    assert list(Station.objects.all()[0].parameters.all()) == list(
+        Parameter.objects.all()
+    )
     import_state = ImportState.objects.get(data_type=data_type)
     assert import_state.year_number == 2021
     assert import_state.month_number == 12


### PR DESCRIPTION
# Environment data stations, add parameters in use to database

### Trello #557

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. environment_data/api/serializers.py
    * Serialize parameters in use from db
2. environment_data/api/views.py
    * Cache stations list view
3. environment_data/management/commands/import_environment_data.py
    * Save parameters in use to db
4. environment_data/tests/conftest.py
    * Add parameter
5. environment_data/tests/test_api.py
    * Improve parameters in use testing
6. environment_data/tests/test_importer.py
    * Test parameters in use are added
7. environment_data/management/commands/air_quality_utils.py
8. environment_data/migrations/0001_initial.py
    * Format