### PR TITLE
Feature/search add helsinki changes

### DIFF
--- a/services/search/api.py
+++ b/services/search/api.py
@@ -435,7 +435,11 @@ class SearchViewSet(GenericAPIView):
         """
 
         cursor = connection.cursor()
-        cursor.execute(sql, [search_query_str])
+        try:
+            cursor.execute(sql, [search_query_str])
+        except Exception as e:
+            logger.error(f"Error in search query: {e}")
+            raise ParseError("Search query failed.")
         # Note, fetchall() consumes the results and once called returns None.
         all_results = cursor.fetchall()
         all_ids = get_all_ids_from_sql_results(all_results)

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -322,9 +322,9 @@ class SearchViewSet(GenericAPIView):
         if not q_val:
             raise ParseError("Supply search terms with 'q=' ' or input=' '")
 
-        if not re.match(r"^[\w\såäö&|-]+$", q_val):
+        if not re.match(r"^[\w\såäö+&|-]+$", q_val):
             raise ParseError(
-                "Invalid search terms, only letters, numbers, spaces and -&| allowed."
+                "Invalid search terms, only letters, numbers, spaces and +-&| allowed."
             )
 
         types_str = ",".join([elem for elem in QUERY_PARAM_TYPE_NAMES])

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -473,8 +473,9 @@ class SearchViewSet(GenericAPIView):
                 )
 
             services_qs = services_qs.annotate(num_units=Count("units")).order_by(
-                "-units__count"
+                "-num_units"
             )
+
             # order_by() call makes duplicate rows appear distinct. This is solved by
             # fetching the ids and filtering a new queryset using them
             ids = list(services_qs.values_list("id", flat=True))

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -47,6 +47,7 @@ from services.utils import strtobool
 
 from .constants import (
     DEFAULT_MODEL_LIMIT_VALUE,
+    DEFAULT_RANK_THRESHOLD,
     DEFAULT_SEARCH_SQL_LIMIT_VALUE,
     DEFAULT_SRS,
     DEFAULT_TRIGRAM_THRESHOLD,
@@ -340,9 +341,17 @@ class SearchViewSet(GenericAPIView):
             try:
                 trigram_threshold = float(params.get("trigram_threshold"))
             except ValueError:
-                raise ParseError("'trigram_threshold' need to be of type float.")
+                raise ParseError("'trigram_threshold' needs to be of type float.")
         else:
             trigram_threshold = DEFAULT_TRIGRAM_THRESHOLD
+
+        if "rank_threshold" in params:
+            try:
+                rank_threshold = float(params.get("rank_threshold"))
+            except ValueError:
+                raise ParseError("'rank_threshold' needs to be of type float.")
+        else:
+            rank_threshold = DEFAULT_RANK_THRESHOLD
 
         if "use_websearch" in params:
             try:
@@ -428,12 +437,13 @@ class SearchViewSet(GenericAPIView):
         # This is ~100 times faster than using Djangos SearchRank and allows searching using wildard "|*"
         # and by rankig gives better results, e.g. extra fields weight is counted.
         sql = f"""
-        SELECT id, type_name, name_{language_short}, ts_rank_cd(search_column_{language_short}, search_query)
-        AS rank FROM search_view, {search_fn}('{config_language}', %s) search_query
-        WHERE search_query @@ search_column_{language_short}
-        ORDER BY rank DESC LIMIT {sql_query_limit};
+            SELECT * from (
+                SELECT id, type_name, name_{language_short}, ts_rank_cd(search_column_{language_short}, search_query)
+                AS rank FROM search_view, {search_fn}('{config_language}','{search_query_str}') search_query
+                WHERE search_query @@ search_column_{language_short}
+                ORDER BY rank DESC LIMIT {sql_query_limit}
+            ) AS sub_query where sub_query.rank >= {rank_threshold};
         """
-
         cursor = connection.cursor()
         try:
             cursor.execute(sql, [search_query_str])

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -24,6 +24,7 @@ from itertools import chain
 
 from django.db import connection, reset_queries
 from django.db.models import Count
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from munigeo import api as munigeo_api
 from munigeo.models import Address, AdministrativeDivision
 from rest_framework import serializers
@@ -182,6 +183,130 @@ class SearchSerializer(serializers.Serializer):
         return representation
 
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter(
+            name="q",
+            location=OpenApiParameter.QUERY,
+            description="The query string used for searching. Searches the search_columns for the given models. Commas "
+            "between words are interpreted as 'and' operator. Words ending with the '|' sign are interpreted as 'or' "
+            "operator.",
+            required=False,
+            type=str,
+        ),
+        OpenApiParameter(
+            name="type",
+            location=OpenApiParameter.QUERY,
+            description="Comma separated list of types to search for. Valid values are: unit, service, servicenode, "
+            "address, administrativedivision. If not given defaults to all.",
+            required=False,
+            type=str,
+        ),
+        OpenApiParameter(
+            name="use_trigram",
+            location=OpenApiParameter.QUERY,
+            description="Comma separated list of types that will include trigram results in search if no results are "
+            "found. Valid values are: unit, service, servicenode, address, administrativedivision. If not given "
+            "trigram will not be used.",
+            required=False,
+            type=str,
+        ),
+        OpenApiParameter(
+            name="trigram_threshold",
+            location=OpenApiParameter.QUERY,
+            description="Threshold value for trigram search. If not given defaults to 0.15.",
+            required=False,
+            type=float,
+        ),
+        OpenApiParameter(
+            name="rank_threshold",
+            location=OpenApiParameter.QUERY,
+            description="Include results with search rank greater than or equal to the value. If not given defaults to "
+            "0.",
+            required=False,
+            type=float,
+        ),
+        OpenApiParameter(
+            name="use_websearch",
+            location=OpenApiParameter.QUERY,
+            description="Use websearch_to_tsquery instead of to_tsquery if exlusion rules are defined for the search.",
+            required=False,
+            type=bool,
+        ),
+        OpenApiParameter(
+            name="geometry",
+            location=OpenApiParameter.QUERY,
+            description="Display geometry of the search result. If not given defaults to false.",
+            required=False,
+            type=bool,
+        ),
+        OpenApiParameter(
+            name="order_units_by_num_services",
+            location=OpenApiParameter.QUERY,
+            description="Order units by number of services. If not given defaults to true.",
+            required=False,
+            type=bool,
+        ),
+        OpenApiParameter(
+            name="include",
+            location=OpenApiParameter.QUERY,
+            description="Comma separated list of fields to include in the response. Format: entity.field, e.g., "
+            "unit.connections.",
+            required=False,
+            type=str,
+        ),
+        OpenApiParameter(
+            name="sql_query_limit",
+            location=OpenApiParameter.QUERY,
+            description="Limit the number of results in the search query.",
+            required=False,
+            type=int,
+        ),
+        OpenApiParameter(
+            name="unit_limit",
+            location=OpenApiParameter.QUERY,
+            description="Limit the number of units in the search results.",
+            required=False,
+            type=int,
+        ),
+        OpenApiParameter(
+            name="service_limit",
+            location=OpenApiParameter.QUERY,
+            description="Limit the number of services in the search results.",
+            required=False,
+            type=int,
+        ),
+        OpenApiParameter(
+            name="servicenode_limit",
+            location=OpenApiParameter.QUERY,
+            description="Limit the number of service nodes in the search results.",
+            required=False,
+            type=int,
+        ),
+        OpenApiParameter(
+            name="administrativedivision_limit",
+            location=OpenApiParameter.QUERY,
+            description="Limit the number of administrative divisions in the search results.",
+            required=False,
+            type=int,
+        ),
+        OpenApiParameter(
+            name="address_limit",
+            location=OpenApiParameter.QUERY,
+            description="Limit the number of addresses in the search results.",
+            required=False,
+            type=int,
+        ),
+        OpenApiParameter(
+            name="language",
+            location=OpenApiParameter.QUERY,
+            description="The language to be used in the search. If not given defaults to Finnish. Format: fi, sv, en.",
+            required=False,
+            type=str,
+        ),
+    ],
+    description="Search for units, services, service nodes, addresses and administrative divisions.",
+)
 class SearchViewSet(GenericAPIView):
     queryset = Unit.objects.all()
 

--- a/services/search/constants.py
+++ b/services/search/constants.py
@@ -16,5 +16,4 @@ DEFAULT_MODEL_LIMIT_VALUE = None
 # The limit value for the search query that search the search_view. "NULL" = no limit
 DEFAULT_SEARCH_SQL_LIMIT_VALUE = "NULL"
 DEFAULT_TRIGRAM_THRESHOLD = 0.15
-# If word length is greater or equal then hyphenate word.
-LENGTH_OF_HYPHENATED_WORDS = 8
+DEFAULT_RANK_THRESHOLD = 1

--- a/services/search/tests/conftest.py
+++ b/services/search/tests/conftest.py
@@ -269,6 +269,14 @@ def addresses(streets, municipality):
         number=33,
         full_name="Yliopistonkatu 33",
     )
+    Address.objects.create(
+        municipality_id=municipality.id,
+        location=Point(60.1612283, 24.9478104),
+        id=6,
+        street_id=45,
+        number=1,
+        full_name="Tarkk'ampujankatu 1",
+    )
     Address.objects.update(search_column_fi=get_search_column(Address, "fi"))
     return Address.objects.all()
 
@@ -305,6 +313,7 @@ def streets():
     )
     Street.objects.create(id=43, name="Markulantie", municipality_id="turku")
     Street.objects.create(id=44, name="Yliopistonkatu", municipality_id="turku")
+    Street.objects.create(id=45, name="Tarkk'ampujankatu", municipality_id="turku")
     return Street.objects.all()
 
 

--- a/services/search/tests/conftest.py
+++ b/services/search/tests/conftest.py
@@ -36,7 +36,6 @@ def api_client():
     return APIClient()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def units(
     services,
@@ -106,15 +105,35 @@ def units(
     )
     unit.services.add(5)
     unit.save()
+    unit = Unit.objects.create(
+        id=6,
+        name="Jäähalli",
+        last_modified_time=now(),
+        municipality=municipality,
+        department=department,
+    )
+    # Add service Halli
+    unit.services.add(6)
+    unit.save()
+
+    unit = Unit.objects.create(
+        id=7,
+        name="Palloiluhalli",
+        last_modified_time=now(),
+        municipality=municipality,
+        department=department,
+    )
+    # Add service Halli
+    unit.services.add(6)
+    unit.save()
     update_service_root_service_nodes()
     update_service_counts()
     update_service_node_counts()
     generate_syllables(Unit)
     Unit.objects.update(search_column_fi=get_search_column(Unit, "fi"))
-    return Unit.objects.all()
+    return Unit.objects.all().order_by("id")
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def department(municipality):
     return Department.objects.create(
@@ -125,7 +144,6 @@ def department(municipality):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def accessibility_shortcoming(units):
     unit = Unit.objects.get(name="Biologinen museo")
@@ -134,7 +152,6 @@ def accessibility_shortcoming(units):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def services():
     Service.objects.create(
@@ -167,12 +184,21 @@ def services():
         name_sv="konstisbanor",
         last_modified_time=now(),
     )
+    Service.objects.create(
+        id=6,
+        name="Halli",
+        last_modified_time=now(),
+    )
+    Service.objects.create(
+        id=7,
+        name="Hallinto",
+        last_modified_time=now(),
+    )
     generate_syllables(Service)
     Service.objects.update(search_column_fi=get_search_column(Service, "fi"))
     return Service.objects.all()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def service_nodes(services):
     leisure = ServiceNode.objects.create(
@@ -196,7 +222,6 @@ def service_nodes(services):
     return ServiceNode.objects.all()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def addresses(streets, municipality):
     Address.objects.create(
@@ -248,7 +273,6 @@ def addresses(streets, municipality):
     return Address.objects.all()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def municipality():
     return Municipality.objects.create(
@@ -256,7 +280,6 @@ def municipality():
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def administrative_division_type():
     return AdministrativeDivisionType.objects.get_or_create(
@@ -264,7 +287,6 @@ def administrative_division_type():
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def administrative_division(administrative_division_type):
     adm_div = AdministrativeDivision.objects.get_or_create(
@@ -276,7 +298,6 @@ def administrative_division(administrative_division_type):
     return adm_div
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def streets():
     Street.objects.create(
@@ -287,7 +308,6 @@ def streets():
     return Street.objects.all()
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def exclusion_rules():
     ExclusionRule.objects.create(id=1, word="tekojää", exclusion="-nurmi")

--- a/services/search/tests/test_api.py
+++ b/services/search/tests/test_api.py
@@ -79,7 +79,8 @@ def test_search(
     assert museum_service_node["unit_count"]["municipality"]["turku"] == 1
     assert museum_service_node["unit_count"]["total"] == 1
     # Test that unit "Impivara" is retrieved from service Uimahalli
-    url = reverse("search") + "?q=uimahalli&type=unit"
+    url = reverse("search") + "?q=uimahalli&type=unit&rank_threshold=0"
+
     response = api_client.get(url)
     results = response.json()["results"]
     assert results[0]["name"]["fi"] == "Impivaara"

--- a/services/search/tests/test_api.py
+++ b/services/search/tests/test_api.py
@@ -153,3 +153,51 @@ def test_search(
     )
     response = api_client.get(url)
     assert len(response.json()["results"]) == 4
+
+
+@pytest.mark.django_db
+def test_search_input_query_validation(api_client):
+    # Test that | is allowed in query
+    url = reverse("search") + "?q=halli|museo"
+    response = api_client.get(url)
+    assert response.status_code == 200
+
+    # Test that & is allowed in query
+    url = reverse("search") + "?q=halli&museo"
+    response = api_client.get(url)
+    assert response.status_code == 200
+
+    # Test that - is allowed in query
+    url = reverse("search") + "?q=linja-auto"
+    response = api_client.get(url)
+    assert response.status_code == 200
+
+    # Test that " " is allowed in query
+    url = reverse("search") + "?q=Keskustakirjasto Oodi"
+    response = api_client.get(url)
+    assert response.status_code == 200
+
+    # Test that "ääkköset" are allowed in query
+    url = reverse("search") + "?q=lääkäri"
+    response = api_client.get(url)
+    assert response.status_code == 200
+    url = reverse("search") + "?q=röntgen"
+    response = api_client.get(url)
+    assert response.status_code == 200
+    url = reverse("search") + "?q=åbo"
+    response = api_client.get(url)
+    assert response.status_code == 200
+
+    # Test that numbers are allowed in query
+    url = reverse("search") + "?q=123"
+    response = api_client.get(url)
+    assert response.status_code == 200
+
+    # Test that special characters are not allowed in query
+    url = reverse("search") + "?q=halli("
+    response = api_client.get(url)
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "Invalid search terms, only letters, numbers, spaces and -&| allowed."
+    )

--- a/services/search/tests/test_api.py
+++ b/services/search/tests/test_api.py
@@ -121,6 +121,12 @@ def test_search(
     assert kurrapolku["location"]["type"] == "Point"
     assert kurrapolku["location"]["coordinates"][0] == 60.479032
     assert kurrapolku["location"]["coordinates"][1] == 22.25417
+    # Test address search with apostrophe in query
+    url = reverse("search") + "?q=tarkk'ampujankatu&type=address"
+    response = api_client.get(url)
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["name"]["fi"] == "Tarkk'ampujankatu 1"
     # Test that addresses are sorted by naturalsort.
     url = reverse("search") + "?q=yliopistonkatu&type=address"
     response = api_client.get(url)
@@ -199,13 +205,23 @@ def test_search_input_query_validation(api_client):
     response = api_client.get(url)
     assert response.status_code == 200
 
+    # Test that . is allowed in query
+    url = reverse("search") + "?q=halli.museo"
+    response = api_client.get(url)
+    assert response.status_code == 200
+
+    # Test that ' is allowed in query
+    url = reverse("search") + "?q=halli's"
+    response = api_client.get(url)
+    assert response.status_code == 200
+
     # Test that special characters are not allowed in query
     url = reverse("search") + "?q=halli("
     response = api_client.get(url)
     assert response.status_code == 400
     assert (
         response.json()["detail"]
-        == "Invalid search terms, only letters, numbers, spaces and +-&| allowed."
+        == "Invalid search terms, only letters, numbers, spaces and .'+-&| allowed."
     )
 
 

--- a/services/search/tests/test_api.py
+++ b/services/search/tests/test_api.py
@@ -207,3 +207,22 @@ def test_search_input_query_validation(api_client):
         response.json()["detail"]
         == "Invalid search terms, only letters, numbers, spaces and +-&| allowed."
     )
+
+
+@pytest.mark.django_db
+def test_search_service_order(api_client, units, services):
+    """
+    Test that services are ordered descending by unit count.
+    """
+    url = reverse("search") + "?q=halli&type=service"
+    response = api_client.get(url)
+    results = response.json()["results"]
+    assert len(results) == 3
+    assert results[0]["name"]["fi"] == "Halli"
+    assert results[0]["unit_count"]["total"] == 2
+
+    assert results[1]["name"]["fi"] == "Uimahalli"
+    assert results[1]["unit_count"]["total"] == 1
+
+    assert results[2]["name"]["fi"] == "Hallinto"
+    assert results[2]["unit_count"]["total"] == 0

--- a/services/search/tests/test_api.py
+++ b/services/search/tests/test_api.py
@@ -177,6 +177,11 @@ def test_search_input_query_validation(api_client):
     response = api_client.get(url)
     assert response.status_code == 200
 
+    # Test that + is allowed in query
+    url = reverse("search") + "?q=Keskustakirjasto+Oodi"
+    response = api_client.get(url)
+    assert response.status_code == 200
+
     # Test that "ääkköset" are allowed in query
     url = reverse("search") + "?q=lääkäri"
     response = api_client.get(url)
@@ -199,5 +204,5 @@ def test_search_input_query_validation(api_client):
     assert response.status_code == 400
     assert (
         response.json()["detail"]
-        == "Invalid search terms, only letters, numbers, spaces and -&| allowed."
+        == "Invalid search terms, only letters, numbers, spaces and +-&| allowed."
     )

--- a/services/search/utils.py
+++ b/services/search/utils.py
@@ -186,15 +186,14 @@ def get_preserved_order(ids):
 def get_trigram_results(
     model, model_name, field, q_val, threshold=DEFAULT_TRIGRAM_THRESHOLD
 ):
-    sql = f"""SELECT id, similarity({field}, '{q_val}') AS sml
+    sql = f"""SELECT id, similarity({field}, %s) AS sml
         FROM {model_name}
-        WHERE  similarity({field}, '{q_val}') >= {threshold}
+        WHERE  similarity({field},%s) >= {threshold}
         ORDER BY sml DESC;
     """
     cursor = connection.cursor()
-    cursor.execute(sql)
+    cursor.execute(sql, [q_val, q_val])
     all_results = cursor.fetchall()
-
     ids = [row[0] for row in all_results]
     objs = model.objects.filter(id__in=ids)
     return objs

--- a/services/search/utils.py
+++ b/services/search/utils.py
@@ -5,7 +5,6 @@ from django.db.models import Case, When
 from services.models import ExclusionRule, ServiceNode, ServiceNodeUnitCount, Unit
 from services.search.constants import (
     DEFAULT_TRIGRAM_THRESHOLD,
-    LENGTH_OF_HYPHENATED_WORDS,
     SEARCHABLE_MODEL_TYPE_NAMES,
 )
 
@@ -13,17 +12,22 @@ voikko = libvoikko.Voikko("fi")
 voikko.setNoUglyHyphenation(True)
 
 
+def is_compound_word(word):
+    result = voikko.analyze(word)
+    if len(result) == 0:
+        return False
+    return True if result[0]["WORDBASES"].count("+") > 1 else False
+
+
 def hyphenate(word):
     """
-    Returns a list of syllables of the word if word length
-    is >= LENGTH_OF_HYPHENATE_WORDS
+    Returns a list of syllables of the word if it is a compound word.
     """
-    word_length = len(word)
-    if word_length >= LENGTH_OF_HYPHENATED_WORDS:
-        # By Setting the value to word_length, voikko returns
-        # the words that are in the compound word, if the word is
-        # not a compound word it returns the syllables as normal.
-        voikko.setMinHyphenatedWordLength(word_length)
+    word = word.strip()
+    if is_compound_word(word):
+        # By Setting the setMinHyphenatedWordLength to word_length,
+        # voikko returns the words that are in the compound word
+        voikko.setMinHyphenatedWordLength(len(word))
         syllables = voikko.hyphenate(word)
         return syllables.split("-")
     else:

--- a/smbackend/settings.py
+++ b/smbackend/settings.py
@@ -357,6 +357,7 @@ DOC_ENDPOINTS = [
     "/environment_data/api/v1/data/",
     "/exceptional_situations/api/v1/situation/",
     "/exceptional_situations/api/v1/situation_type/",
+    "/api/v2/search",
 ]
 
 


### PR DESCRIPTION
# Add changes to search made by Helsinki


### Trello #578

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Contains the following changes made by Helsinki
* Fix service search results order 
* Add option to disable provider_type ordering in search [#243](https://github.com/City-of-Helsinki/smbackend/pull/243)
* Accept dot and apostrophe in search validation [#241](https://github.com/City-of-Helsinki/smbackend/pull/241)
* Catch potential tsquery errors more gracefully [#235](https://github.com/City-of-Helsinki/smbackend/pull/235)
* Accept plus sign in search validation [#224](https://github.com/City-of-Helsinki/smbackend/pull/224)
* Validate search query input [#213](https://github.com/City-of-Helsinki/smbackend/pull/213)
* OpenApi : document search API parameters [#210](https://github.com/City-of-Helsinki/smbackend/pull/210)
* Filter by rank and hyphenate only compound words
#### Additional changes
1. smbackend/settings.py
    * Make API documentation visible
2. services/search/utils.py
   * Fix function get_trigram_results to work with apostrophe