### PR TITLE
Feature/eco counter ensure data on initial import

### DIFF
--- a/eco_counter/management/commands/import_counter_data.py
+++ b/eco_counter/management/commands/import_counter_data.py
@@ -435,23 +435,19 @@ def get_csv_data(counter, import_state, start_time, verbose=True):
                 start_year = TRAFFIC_COUNTER_START_YEAR
             csv_data = get_traffic_counter_csv(start_year=start_year)
 
-    if counter == TELRAAM_COUNTER:
-        save_telraam_data(start_time)
-    else:
-        start_time_string = start_time.strftime("%Y-%m-%dT%H:%M")
-        start_index = csv_data.index[
-            csv_data[INDEX_COLUMN_NAME] == start_time_string
-        ].values[0]
-        if verbose:
-            # As LAM data is fetched with a timespan, no index data is available, instead
-            # show time.
-            if counter == LAM_COUNTER:
-                logger.info(f"Starting saving observations at time:{start_time}")
-            else:
-                logger.info(f"Starting saving observations at index:{start_index}")
+    start_time_string = start_time.strftime("%Y-%m-%dT%H:%M")
+    start_index = csv_data.index[
+        csv_data[INDEX_COLUMN_NAME] == start_time_string
+    ].values[0]
+    if verbose:
+        # As LAM data is fetched with a timespan, no index data is available, instead display start_time.
+        if counter == LAM_COUNTER:
+            logger.info(f"Starting saving observations at time:{start_time}")
+        else:
+            logger.info(f"Starting saving observations at index:{start_index}")
 
-        csv_data = csv_data[start_index:]
-        return csv_data
+    csv_data = csv_data[start_index:]
+    return csv_data
 
 
 def import_data(counters, initial_import=False, force=False):
@@ -480,15 +476,19 @@ def import_data(counters, initial_import=False, force=False):
             break
 
         start_time = get_start_time(counter, import_state)
-        csv_data = get_csv_data(counter, import_state, start_time)
-        save_observations(
-            csv_data,
-            start_time,
-            csv_data_source=counter,
-        )
-        # Try to free some memory
-        del csv_data
-        gc.collect()
+
+        if counter == TELRAAM_COUNTER:
+            save_telraam_data(start_time)
+        else:
+            csv_data = get_csv_data(counter, import_state, start_time)
+            save_observations(
+                csv_data,
+                start_time,
+                csv_data_source=counter,
+            )
+            # Try to free some memory
+            del csv_data
+            gc.collect()
 
 
 def add_additional_data_to_stations(csv_data_source):

--- a/eco_counter/management/commands/utils.py
+++ b/eco_counter/management/commands/utils.py
@@ -258,6 +258,11 @@ def get_traffic_counter_csv(start_year=2015):
 
 def get_lam_dataframe(csv_url):
     response = requests.get(csv_url, headers=LAM_STATION_USER_HEADER)
+    assert (
+        response.status_code == 200
+    ), "Fetching LAM data from {} , status code {}".format(
+        settings.ECO_COUNTER_STATIONS_URL, response.status_code
+    )
     string_data = response.content
     csv_data = pd.read_csv(io.StringIO(string_data.decode("utf-8")), delimiter=";")
     return csv_data

--- a/eco_counter/tasks.py
+++ b/eco_counter/tasks.py
@@ -14,6 +14,11 @@ def initial_import_counter_data(args, name="initial_import_counter_data"):
 
 
 @shared_task_email
+def force_initial_import_counter_data(args, name="force_initial_import_counter_data"):
+    management.call_command("import_counter_data", "--force", "--init", args)
+
+
+@shared_task_email
 def delete_counter_data(args, name="delete_counter_data"):
     management.call_command("delete_counter_data", "--counters", args)
 


### PR DESCRIPTION
# Ensure data on initial import
## Description
To avoid deleting data when source data is offline or has missing data.


### Trello #112

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. eco_counter/management/commands/import_counter_data.py
    * Delete data on initial import only if data is available. Add --force option.
2. eco_counter/tasks.py
    * Add task to forcibly run initial import 
3. eco_counter/management/commands/utils.py
    * Assert response status code
