### PR TITLE
Feature/import parking machines from wfs

### DIFF
--- a/mobility_data/README.md
+++ b/mobility_data/README.md
@@ -170,7 +170,6 @@ To import data type:
 ./manage.py import_wfs BarbecuePlace
 ```
 
-
 ### Playgrounds
 ```
 ./manage.py import_wfs PlayGround
@@ -190,7 +189,7 @@ Imports the outdoor gym devices from the services.unit model. i.e., sets referen
 
 ### Parking machines
 ```
-./manage.py import_parking_machines
+./manage.py import_wfs ParkingMachine
 ```
 
 ### School and kindergarten accessibility areas

--- a/mobility_data/importers/data/wfs_importer_config.yml
+++ b/mobility_data/importers/data/wfs_importer_config.yml
@@ -1,4 +1,26 @@
 features:
+  - content_type_name: ParkingMachine
+    wfs_layer: GIS:Pysakointiautomaatit
+    translate_fi_address_field: Osoite
+    translate_fi_address_municipality_id: turku
+    extra_fields:
+      maksutapa_fi:
+        wfs_field: Maksutapa
+      maksutapa_sv:
+        wfs_field: Maksutapa_sv
+      maksutapa_en:
+        wfs_field: Maksutapa_en
+      maksuvyohyke:
+        wfs_field: Maksuvyohyke  
+      taksa:
+        wfs_field: Taksa
+      muu_tieto_fi:
+        wfs_field: Muu_tieto
+      muu_tieto_sv:
+        wfs_field: Muu_tieto_sv
+      muu_tieto_en:
+        wfs_field: Muu_tieto_en
+
   - content_type_name: StreetAreaInformation
     wfs_layer: GIS:Katualueet
     max_features: 100000

--- a/mobility_data/importers/data/wfs_importer_config_example.yml
+++ b/mobility_data/importers/data/wfs_importer_config_example.yml
@@ -16,6 +16,13 @@ features:
     municipality: muni_field
     # Optional, if set, include only if geometry is inside the boundarys of Turku, default=False
     locates_in_turku: True
+    # Optional, Add the field from which the Finnish address is fetched
+    # and get the Swedish and the English translations to it.  
+    # Suitable if only Finnish address is available in the source data.
+    translate_fi_address_field: field_with_finnish_address
+    # Required if "translate_fi_address_field" is used. 
+    # municipality id of the municipality from which to lookup the address translations.
+    translate_fi_address_municipality_id: turku
     # Optional, include only if 'field_name' contains the given string.
     include:
       field_name: this_must_be_in_field_name

--- a/mobility_data/importers/data/wfs_importer_config_example.yml
+++ b/mobility_data/importers/data/wfs_importer_config_example.yml
@@ -17,7 +17,7 @@ features:
     # Optional, if set, include only if geometry is inside the boundarys of Turku, default=False
     locates_in_turku: True
     # Optional, Add the field from which the Finnish address is fetched
-    # and get the Swedish and the English translations to it.  
+    # and the importer will assign and lookup the Swedish and the English translations to it.  
     # Suitable if only Finnish address is available in the source data.
     translate_fi_address_field: field_with_finnish_address
     # Required if "translate_fi_address_field" is used. 

--- a/mobility_data/management/commands/import_parking_machines.py
+++ b/mobility_data/management/commands/import_parking_machines.py
@@ -1,3 +1,9 @@
+"""
+Deprecated, the parking machines will in future be imported with the WFS importer.
+All code related to this importer can be removed after the importing
+from WFS feature is in the production environment.
+"""
+
 import logging
 
 from django.core.management import BaseCommand

--- a/mobility_data/tasks.py
+++ b/mobility_data/tasks.py
@@ -155,7 +155,7 @@ def import_wfs(args=None, name="import_wfs"):
 
 @shared_task_email
 def import_parking_machines(name="import_parking_machines"):
-    management.call_command("import_parking_machines")
+    management.call_command("import_wfs", "ParkingMachine")
 
 
 @shared_task_email

--- a/mobility_data/tests/test_api.py
+++ b/mobility_data/tests/test_api.py
@@ -1,6 +1,4 @@
 import pytest
-from django.conf import settings
-from django.contrib.gis.geos import Point
 from rest_framework.reverse import reverse
 
 
@@ -47,8 +45,8 @@ def test_mobile_unit(api_client, mobile_units, content_types, unit):
     assert result["extra"]["test_string"] == "4242"
     assert result["extra"]["test_int"] == 4242
     assert result["extra"]["test_float"] == 42.42
-    assert result["geometry"] == Point(
-        235404.6706163187, 6694437.919005549, srid=settings.DEFAULT_SRID
+    assert (
+        result["geometry"] == "SRID=3067;POINT (235404.67061631865 6694437.919005549)"
     )
     url = reverse(
         "mobility_data:mobile_units-detail",


### PR DESCRIPTION
# Import parking machines from WFS


### Trello #105

-----------------------------------------------------------------------------------------------
### Breakdown:

#### WFS importer
1. mobility_data/importers/data/wfs_importer_config.yml
    * Add configuration for parking machines
2. mobility_data/importers/data/wfs_importer_config_example.yml
    * Add translate_fi_address_field and translate_fi_address_municipality_id
3. mobility_data/importers/wfs.py
    * Add feature to store address with translations
4. 
#### Other
1. mobility_data/README.md
   * Update info about importing parking machines
2. mobility_data/management/commands/import_parking_machines.py
    * Add deprecation info
3. mobility_data/tasks.py
    * Import parking machines with the WFS importer
4. mobility_data/tests/test_api.py
    * Fix faulty assertion