### PR TITLE
Feature/exceptional situations admin replace osmgeoadmin with gismodeladmin

### DIFF
--- a/exceptional_situations/admin.py
+++ b/exceptional_situations/admin.py
@@ -20,7 +20,7 @@ class SituationAnnouncementAdmin(admin.ModelAdmin):
     list_display = ("title", "start_time", "end_time")
 
 
-class SituationLocationAdmin(admin.OSMGeoAdmin):
+class SituationLocationAdmin(admin.GISModelAdmin):
     list_display = ("id", "title", "geometry")
 
     def title(self, obj):


### PR DESCRIPTION
# Replace OSMGeoAdmin with GISModelAdmin
Removes deprecated in Django 5.0 warning

### Trello #618

-