### PR TITLE
Fix/eco counter handle erroneous weeks in data migration 0024

### DIFF
--- a/eco_counter/migrations/0024_data_migration_remove_useless_entities_and_updated_relations.py
+++ b/eco_counter/migrations/0024_data_migration_remove_useless_entities_and_updated_relations.py
@@ -99,6 +99,9 @@ class Migration(migrations.Migration):
         for item in keep_weeks.items():
             week = item[1]
             year_numbers = item[0].split("_")[:-1]
+            # Handle erroneous weeks without a year.
+            if year_numbers == [""]:
+                continue
             week.years.clear()
             for year_number in year_numbers:
                 week.years.add(keep_years[year_number])


### PR DESCRIPTION
# Handle erroneous weeks without a year


### [Trello](https://trello.com/c/JeJmjFUZ/636-eco-counter-migraatio-0024datamigrationremoveuselessentitiesandupdatedrelations-kaatu-jos-viallista-viikkodata)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### File changed
 1. eco_counter/migrations/0024_data_migration_remove_useless_entities_and_updated_relations.py
     * Handle erroneous weeks without a year
 