### PR TITLE
fix/bicycle-stands-importer-add-default-values

### DIFF
--- a/mobility_data/importers/bicycle_stands.py
+++ b/mobility_data/importers/bicycle_stands.py
@@ -168,12 +168,17 @@ class BicyleStand(MobileUnitDataBase):
             self.extra["number_of_places"] = sum(numbers)
 
         quality_elem = feature["Pyorapaikkojen_laatutaso"].as_string()
+        
+        self.extra.setdefault("hull_lockable", None)
+        self.extra.setdefault("covered", None)
+
         if quality_elem:
             quality_text = quality_elem.lower()
             if self.WFS_HULL_LOCKABLE_STR in quality_text:
                 self.extra["hull_lockable"] = True
             else:
                 self.extra["hull_lockable"] = False
+
             if self.COVERED_IN_STR in quality_text:
                 self.extra["covered"] = True
             else:

--- a/mobility_data/importers/bicycle_stands.py
+++ b/mobility_data/importers/bicycle_stands.py
@@ -168,7 +168,7 @@ class BicyleStand(MobileUnitDataBase):
             self.extra["number_of_places"] = sum(numbers)
 
         quality_elem = feature["Pyorapaikkojen_laatutaso"].as_string()
-        
+
         self.extra.setdefault("hull_lockable", None)
         self.extra.setdefault("covered", None)
 


### PR DESCRIPTION
# Add default value to keys 'hull_locakble' and 'covered'

Loosely relates to Trello [#624](https://trello.com/c/G7vIbnB9)