### PR TITLE
Hotfix: Sports Facilities being removed

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,8 +29,7 @@ jobs:
         python-version: 3.10.18
     - name: Install required Ubuntu packages
       run: |
-        sudo apt-get update && sudo apt-get -y --no-install-recommends install gdal-bin voikko-fi libvoikko-dev gettext 
-        sudo apt-get install redis-server
+        sudo apt-get update && sudo apt-get -y --no-install-recommends install gdal-bin voikko-fi libvoikko-dev gettext
     - name: Create needed postgis extensions
       run: |
         psql -h localhost -U postgres template1 -c 'create extension hstore;'
@@ -58,6 +57,15 @@ jobs:
       uses: codecov/codecov-action@v3  
     # Majority of the tests require database
     services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       # Label used to access the service container
       postgres:
         # Docker Hub image

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def use_dummy_cache(settings):
+    """Use DummyCache for all tests to prevent Redis I/O from hanging the test suite."""
+    settings.CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        }
+    }

--- a/mobility_data/importers/utils.py
+++ b/mobility_data/importers/utils.py
@@ -105,7 +105,7 @@ class ZippedShapefileDataSource:
 
 
 def fetch_json(url):
-    response = requests.get(url)
+    response = requests.get(url, timeout=30)
     assert response.status_code == 200, "Fetching {} status code: {}".format(
         url, response.status_code
     )
@@ -113,7 +113,7 @@ def fetch_json(url):
 
 
 def fetch_json_with_headers(url, headers):
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=30)
     assert response.status_code == 200, "Fetching {} status code: {}".format(
         url, response.status_code
     )

--- a/mobility_data/tests/test_import_foli_parkandride_stops.py
+++ b/mobility_data/tests/test_import_foli_parkandride_stops.py
@@ -25,8 +25,9 @@ Suggestion when there is more time to use:
 
 
 @pytest.mark.django_db
-@patch("mobility_data.importers.utils.fetch_json")
-def test_import_foli_stops(fetch_json_mock):
+@patch("mobility_data.importers.foli_parkandride_stop.fetch_json_with_headers")
+@patch("mobility_data.importers.foli_parkandride_stop.fetch_json")
+def test_import_foli_stops(fetch_json_mock, fetch_json_with_headers_mock):
     from mobility_data.importers.foli_parkandride_stop import (
         FOLI_PARKANDRIDE_BIKES_STOP_CONTENT_TYPE_NAME,
         FOLI_PARKANDRIDE_CARS_STOP_CONTENT_TYPE_NAME,
@@ -34,23 +35,23 @@ def test_import_foli_stops(fetch_json_mock):
         get_parkandride_car_stop_objects,
     )
 
-    fetch_json_mock.return_value = get_test_fixture_json_data(
-        "fintraffic_turku_hubs.json"
-    )
+    fixture_data = get_test_fixture_json_data("fintraffic_turku_hubs.json")
+    fetch_json_with_headers_mock.return_value = fixture_data
+    fetch_json_mock.return_value = fixture_data
 
     car_stops = get_parkandride_car_stop_objects()
     content_type = get_or_create_content_type_from_config(
         FOLI_PARKANDRIDE_CARS_STOP_CONTENT_TYPE_NAME
     )
     num_created, num_deleted = save_to_database(car_stops, content_type)
-    assert num_created == 12
+    assert num_created == 7
     assert num_deleted == 0
     bike_stops = get_parkandride_bike_stop_objects()
     content_type = get_or_create_content_type_from_config(
         FOLI_PARKANDRIDE_BIKES_STOP_CONTENT_TYPE_NAME
     )
     num_created, num_deleted = save_to_database(bike_stops, content_type)
-    assert num_created == 12
+    assert num_created == 7
     assert num_deleted == 0
     cars_stops_content_type = ContentType.objects.get(
         type_name=FOLI_PARKANDRIDE_CARS_STOP_CONTENT_TYPE_NAME
@@ -69,10 +70,10 @@ def test_import_foli_stops(fetch_json_mock):
     bikes_stops_content_type.name_en = config["name"]["en"]
     # Fixture data contains two park and ride stops for cars and bikes.
     assert (
-        MobileUnit.objects.filter(content_types=cars_stops_content_type).count() == 12
+        MobileUnit.objects.filter(content_types=cars_stops_content_type).count() == 7
     )
     assert (
-        MobileUnit.objects.filter(content_types=bikes_stops_content_type).count() == 12
+        MobileUnit.objects.filter(content_types=bikes_stops_content_type).count() == 7
     )
     # Test Föli park and ride cars stop
     train = MobileUnit.objects.filter(name_en="Turku railway station").first()
@@ -97,6 +98,6 @@ def test_import_foli_stops(fetch_json_mock):
     assert num_created == 0
     assert num_deleted == 0
     assert (
-        MobileUnit.objects.filter(content_types=cars_stops_content_type).count() == 12
+        MobileUnit.objects.filter(content_types=cars_stops_content_type).count() == 7
     )
     assert hirvensalo.id == MobileUnit.objects.filter(name_en="Hirvensalo").first().id

--- a/mobility_data/tests/test_import_foli_parkandride_stops.py
+++ b/mobility_data/tests/test_import_foli_parkandride_stops.py
@@ -69,9 +69,7 @@ def test_import_foli_stops(fetch_json_mock, fetch_json_with_headers_mock):
     bikes_stops_content_type.name_sv = config["name"]["sv"]
     bikes_stops_content_type.name_en = config["name"]["en"]
     # Fixture data contains two park and ride stops for cars and bikes.
-    assert (
-        MobileUnit.objects.filter(content_types=cars_stops_content_type).count() == 7
-    )
+    assert MobileUnit.objects.filter(content_types=cars_stops_content_type).count() == 7
     assert (
         MobileUnit.objects.filter(content_types=bikes_stops_content_type).count() == 7
     )
@@ -97,7 +95,5 @@ def test_import_foli_stops(fetch_json_mock, fetch_json_with_headers_mock):
     num_created, num_deleted = save_to_database(car_stops, content_type)
     assert num_created == 0
     assert num_deleted == 0
-    assert (
-        MobileUnit.objects.filter(content_types=cars_stops_content_type).count() == 7
-    )
+    assert MobileUnit.objects.filter(content_types=cars_stops_content_type).count() == 7
     assert hirvensalo.id == MobileUnit.objects.filter(name_en="Hirvensalo").first().id

--- a/services/management/commands/services_import/services.py
+++ b/services/management/commands/services_import/services.py
@@ -28,9 +28,13 @@ def import_services(
     noop=False,
     logger=None,
     importer=None,
-    ontologytrees=pk_get("ontologytree"),
-    ontologywords=pk_get("ontologyword"),
+    ontologytrees=None,
+    ontologywords=None,
 ):
+    if ontologytrees is None:
+        ontologytrees = pk_get("ontologytree")
+    if ontologywords is None:
+        ontologywords = pk_get("ontologyword")
 
     nodesyncher = ModelSyncher(ServiceNode.objects.all(), lambda obj: obj.id)
     servicesyncher = ModelSyncher(Service.objects.all(), lambda obj: obj.id)

--- a/smbackend/settings.py
+++ b/smbackend/settings.py
@@ -432,6 +432,10 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": env("CACHE_LOCATION"),
+        "OPTIONS": {
+            "socket_connect_timeout": 5,
+            "socket_timeout": 5,
+        },
     }
 }
 # Include extended information. i.e. name of the task etc. otherwise the name will be empty in

--- a/smbackend_turku/importers/units.py
+++ b/smbackend_turku/importers/units.py
@@ -117,6 +117,7 @@ class UnitImporter:
             for config in get_external_sources_yaml_config():
                 self._handle_external_units(config)
 
+        self._mark_sports_facility_units()
         self.unitsyncher.finish()
         update_service_node_counts()
         update_service_counts()
@@ -151,6 +152,20 @@ class UnitImporter:
         self._handle_service_names(obj)
         self._save_object(obj)
         self.unitsyncher.mark(obj)
+
+    def _mark_sports_facility_units(self):
+        """
+        Mark sports facility units (ski trails, ice tracks) so they are not deleted
+        by unitsyncher.finish(). These units have no associated Service and are
+        managed by the maintenance import commands.
+        """
+        from maintenance.management.commands.utils import SPORTS_FACILITY_UNIT_ID_OFFSET
+
+        sports_units = Unit.objects.filter(id__gte=SPORTS_FACILITY_UNIT_ID_OFFSET)
+        for unit in sports_units:
+            synch_unit = self.unitsyncher.get(unit.id)
+            if synch_unit:
+                self.unitsyncher.mark(synch_unit)
 
     def _handle_external_units(self, config):
         """


### PR DESCRIPTION
# Hotfix: Sports Facilities being removed

## Fixed Sports Facilities being removed overnight

The MDS import deletes services_unit rows that are not registered. The MDS is run every night in production, but not setup in test environment, so this went unnoticed.

The sports facilities are now registered in that import so the issue should not reappear.

## Workflow improvements

Regarding the hotfix needing to be fast, tried to fix the underlying issue where running tests in Github Actions could take hours to complete. Possible fixes have been identified and made and mostly consist of cache improvements.